### PR TITLE
Fix ValueError issue when decoding a message.

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -207,10 +207,10 @@ class SerialGateway(Gateway, threading.Thread):
                 continue
             try:
                 msg = line.decode('utf-8')
+                response = self.logic(msg)
             except ValueError:
-                LOGGER.exception('')
+                LOGGER.exception('Error decoding message from gateway')
                 continue
-            response = self.logic(msg)
             if response is not None:
                 try:
                     self.send(response.encode())


### PR DESCRIPTION
This seems to happen occasionally when starting/stopping the serial
thread due to partial messages in the buffer.