### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='pymysensors',
+      version='0.1',
+      description='Python API for talking to a MySensors gateway',
+      url='https://github.com/theolind/pymysensors',
+      author='Theodor Lindquist',
+      license='MIT',
+      install_requires=['pyserial>=2.7'],
+      packages=['mysensors'],
+      zip_safe=True)


### PR DESCRIPTION
By adding a `setup.py` file people will be able to install your repository by referring to it from  `requirements.txt`. And that, is exactly what I am planning to do for Home Assistant.