### PR TITLE
Json support

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -261,7 +261,11 @@ class SerialGateway(Gateway, threading.Thread):
                 msg = line.decode('utf-8')
                 response = self.logic(msg)
             except ValueError:
-                LOGGER.warning('Error decoding message from gateway, probably received bad byte.')
+                LOGGER.warning('Error decoding message from gateway, '
+                               'probably received bad byte.')
+                continue
+            except UnicodeDecodeError:
+                LOGGER.exception('Unable to decode message from gateway')
                 continue
             if response is not None:
                 try:

--- a/tests/test.py
+++ b/tests/test.py
@@ -102,7 +102,27 @@ class TestGateway(unittest.TestCase):
         del self.gw.sensors[1]
         self.gw._load_sensors()
         self.assertEqual(self.gw.sensors[1].sketch_name, sensor.sketch_name)
-        self.assertEqual(self.gw.sensors[1].sketch_version, sensor.sketch_version)
+        self.assertEqual(self.gw.sensors[1].sketch_version,
+                         sensor.sketch_version)
+        self.assertEqual(self.gw.sensors[1].battery_level, sensor.battery_level)
+        self.assertEqual(self.gw.sensors[1].type, sensor.type)
+
+    def test_json_persistence(self):
+        sensor = self._add_sensor(1)
+        sensor.children[0] = my.ChildSensor(0, Presentation.S_LIGHT_LEVEL)
+        self.gw.sensors[1].type = Presentation.S_ARDUINO_NODE
+        self.gw.sensors[1].sketch_name = "testsketch"
+        self.gw.sensors[1].sketch_version = "1.0"
+        self.gw.sensors[1].battery_level = 78
+
+        sensor = self.gw.sensors[1]
+        self.gw.persistence_file = "persistance.file.json"
+        self.gw._save_sensors()
+        del self.gw.sensors[1]
+        self.gw._load_sensors()
+        self.assertEqual(self.gw.sensors[1].sketch_name, sensor.sketch_name)
+        self.assertEqual(self.gw.sensors[1].sketch_version,
+                         sensor.sketch_version)
         self.assertEqual(self.gw.sensors[1].battery_level, sensor.battery_level)
         self.assertEqual(self.gw.sensors[1].type, sensor.type)
 


### PR DESCRIPTION
Adds support for serializing the sensors to a JSON file based upon the filename extension.  The default behavior is still to save a pickle, unless the user passes in a different persistence_file value.

This also contains a potential fix for [this issue](https://groups.google.com/d/msg/home-assistant-dev/D2VAC7uDt-Q/k4-2_76_DwAJ).