### PR TITLE
Pass protocol version through from SerialGateway to Gateway.

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -206,10 +206,11 @@ class SerialGateway(Gateway, threading.Thread):
     # pylint: disable=too-many-arguments
 
     def __init__(self, port, event_callback=None, persistence=False,
-                 persistence_file="mysensors.pickle",
+                 persistence_file="mysensors.pickle", protocol_version="1.4",
                  baud=115200, timeout=1.0, reconnect_timeout=10.0):
         threading.Thread.__init__(self)
-        Gateway.__init__(self, event_callback, persistence, persistence_file)
+        Gateway.__init__(self, event_callback, persistence, persistence_file,
+                         protocol_version)
         self.serial = None
         self.port = port
         self.baud = baud


### PR DESCRIPTION
The SerialGateway constructor was missing the protocol_version parameter.

If this is accepted, then I'll send a pull request to HA for [this commit](https://github.com/andythigpen/home-assistant/commit/56bf828ff0b27863b4e6952cb86e2a4cf4145a1c) to add support for these changes there.