### PR TITLE
Bump the version number to 0.3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pymysensors',
-      version='0.2',
+      version='0.3',
       description='Python API for talking to a MySensors gateway',
       url='https://github.com/theolind/pymysensors',
       author='Theodor Lindquist',


### PR DESCRIPTION
I wanted to integrate the JSON changes into HA, and it looks like the dependency manager requires a new version (https://github.com/balloob/home-assistant/pull/494).