### PR TITLE
Fifo queue, implementing switches

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,12 @@
 import mysensors.mysensors as mysensors
 
+
 def event(type, nid):
-    print(type+" "+str(nid))
+    print(type + " " + str(nid))
 
 gw = mysensors.SerialGateway('/dev/ttyACM0', event, True)
 gw.debug = True
 gw.start()
+# To set sensor 2, child 1, sub-type V_LIGHT (= 2), with value 1.
+gw.set_child_value(2, 1, 2, 1)
+gw.stop()

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -8,6 +8,7 @@ import logging
 import pickle
 import os
 import json
+from queue import Queue
 
 # Correct versions will be dynamically imported when creating a gateway
 global Internal, MessageType
@@ -16,10 +17,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Gateway(object):
+
     """ Base implementation for a MySensors Gateway. """
 
     def __init__(self, event_callback=None, persistence=False,
                  persistence_file="mysensors.pickle", protocol_version="1.4"):
+        self.queue = Queue()
         self.event_callback = event_callback
         self.sensors = {}
         self.metric = True   # if true - use metric, if false - use imperial
@@ -29,9 +32,17 @@ class Gateway(object):
         if persistence:
             self._load_sensors()
         if protocol_version == "1.4":
-            _const = __import__("mysensors.const_14", globals(), locals(), ['Internal', 'MessageType'], 0)
+            _const = __import__("mysensors.const_14",
+                                globals(),
+                                locals(),
+                                ['Internal', 'MessageType'],
+                                0)
         elif protocol_version == "1.5":
-            _const = __import__("mysensors.const_15", globals(), locals(), ['Internal', 'MessageType'], 0)
+            _const = __import__("mysensors.const_15",
+                                globals(),
+                                locals(),
+                                ['Internal', 'MessageType'],
+                                0)
         global Internal, MessageType
         Internal = _const.Internal
         MessageType = _const.MessageType
@@ -200,17 +211,49 @@ class Gateway(object):
             return child_id in self.sensors[sensorid].children
         return True
 
+    def handle_queue(self, queue=None):
+        """If queue is not empy, get the function and any args and kwargs
+        from the queue. Run the function and return output."""
+        if queue is None:
+            queue = self.queue
+        if not queue.empty():
+            func, args, kwargs = queue.get()
+            reply = func(*args, **kwargs)
+            queue.task_done()
+            return reply
+        return None
+
+    def fill_queue(self, func, args=None, kwargs=None, queue=None):
+        """Put the function 'f', a tuple of arguments 'args' and a dict
+        of keyword arguments 'kwargs', as a tuple in the queue."""
+        if args is None:
+            args = ()
+        if kwargs is None:
+            kwargs = {}
+        if queue is None:
+            queue = self.queue
+        queue.put((func, args, kwargs))
+
+    def set_child_value(self, sensor_id, child_id, value_type, value):
+        """Add a command to set a sensor value, to the queue.
+        A queued command will be sent to the sensor, when the gateway
+        thread has sent all previously queued commands to the FIFO queue."""
+        self.fill_queue(self.sensors[sensor_id].set_child_value,
+                        (child_id, value_type, value))
+
 
 class SerialGateway(Gateway, threading.Thread):
+
     """ MySensors serial gateway. """
     # pylint: disable=too-many-arguments
 
-    def __init__(self, port, event_callback=None, persistence=False,
-                 persistence_file="mysensors.pickle", protocol_version="1.4",
-                 baud=115200, timeout=1.0, reconnect_timeout=10.0):
+    def __init__(self, port, event_callback=None,
+                 persistence=False, persistence_file="mysensors.pickle",
+                 protocol_version="1.4", baud=115200, timeout=1.0,
+                 reconnect_timeout=10.0):
         threading.Thread.__init__(self)
-        Gateway.__init__(self, event_callback, persistence, persistence_file,
-                         protocol_version)
+        Gateway.__init__(self, event_callback, persistence,
+                         persistence_file, protocol_version)
         self.serial = None
         self.port = port
         self.baud = baud
@@ -221,10 +264,13 @@ class SerialGateway(Gateway, threading.Thread):
     def connect(self):
         """ Connects to the serial port. """
         if self.serial:
+            LOGGER.debug('Already connected to %s', self.port)
             return True
         try:
+            LOGGER.debug('Trying to connect to %s', self.port)
             self.serial = serial.Serial(self.port, self.baud,
                                         timeout=self.timeout)
+            LOGGER.debug('Connected to %s', self.port)
         except serial.SerialException:
             LOGGER.exception('Unable to connect to %s', self.port)
             return False
@@ -233,11 +279,13 @@ class SerialGateway(Gateway, threading.Thread):
     def disconnect(self):
         """ Disconnects from the serial port. """
         if self.serial is not None:
+            LOGGER.debug('Disconnecting from %s', self.port)
             self.serial.close()
             self.serial = None
 
     def stop(self):
         """ Stops the background thread. """
+        LOGGER.debug('Stopping thread')
         self._stop_event.set()
 
     def run(self):
@@ -246,6 +294,13 @@ class SerialGateway(Gateway, threading.Thread):
             if self.serial is None and not self.connect():
                 time.sleep(self.reconnect_timeout)
                 continue
+            response = self.handle_queue()
+            if response is not None:
+                try:
+                    self.send(response.encode())
+                except ValueError:
+                    LOGGER.exception('Invalid response')
+                    continue
             try:
                 line = self.serial.readline()
                 if not line:
@@ -259,17 +314,13 @@ class SerialGateway(Gateway, threading.Thread):
                 self.disconnect()
                 continue
             try:
-                msg = line.decode('utf-8')
-                response = self.logic(msg)
+                string = line.decode('utf-8')
+                self.fill_queue(self.logic, (string,))
             except ValueError:
-                LOGGER.warning('Error decoding message from gateway, probably received bad byte.')
+                LOGGER.warning(
+                    'Error decoding message from gateway,'
+                    ' probably received bad byte.')
                 continue
-            if response is not None:
-                try:
-                    self.send(response.encode())
-                except ValueError:
-                    LOGGER.exception('Invalid response')
-                    continue
 
     def send(self, message):
         """ Writes a Message to the gateway. """
@@ -277,6 +328,7 @@ class SerialGateway(Gateway, threading.Thread):
 
 
 class Sensor:
+
     """ Represents a sensor. """
 
     def __init__(self, sensor_id):
@@ -295,10 +347,16 @@ class Sensor:
         """ Sets a child sensor's value. """
         if child_id in self.children:
             self.children[child_id].values[value_type] = value
+            msg = Message()
+            return msg.copy(node_id=self.sensor_id, child_id=child_id, type=1,
+                            sub_type=value_type, payload=value)
+        return None
+
         # TODO: Handle error
 
 
 class ChildSensor:
+
     """ Represents a child sensor. """
     # pylint: disable=too-few-public-methods
 
@@ -309,14 +367,15 @@ class ChildSensor:
 
 
 class Message:
+
     """ Represents a message from the gateway. """
 
     def __init__(self, data=None):
         self.node_id = 0
         self.child_id = 0
-        self.type = ""
+        self.type = 0
         self.ack = 0
-        self.sub_type = ""
+        self.sub_type = 0
         self.payload = ""
         if data is not None:
             self.decode(data)
@@ -354,6 +413,7 @@ class Message:
 
 
 class MySensorsJSONEncoder(json.JSONEncoder):
+
     def default(self, o):
         if isinstance(o, Sensor):
             return {
@@ -374,6 +434,7 @@ class MySensorsJSONEncoder(json.JSONEncoder):
 
 
 class MySensorsJSONDecoder(json.JSONDecoder):
+
     def __init__(self):
         json.JSONDecoder.__init__(self, object_hook=self.dict_to_object)
 
@@ -389,5 +450,5 @@ class MySensorsJSONDecoder(json.JSONDecoder):
             child.values = o['values']
             return child
         elif all(k.isdigit() for k in o.keys()):
-            return {int(k): v for k,v in o.items()}
+            return {int(k): v for k, v in o.items()}
         return o

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(name='pymysensors',
       url='https://github.com/theolind/pymysensors',
       author='Theodor Lindquist',
       license='MIT',
-      install_requires=['pyserial>=2.7'],
+      install_requires=['pyserial<=2.5'],
       packages=['mysensors'],
       zip_safe=True)


### PR DESCRIPTION
Hi!

This branch implements a new feature that permits sending commands from the controller/gateway to a node. This gives the possibility of controlling switches connected to mysensors nodes.

The basis is a FIFO queue that enables comm with the SerialGateway thread from another thread. The queue is filled by a function fill_queue that puts a function and any arguments on the queue. The queue is handled by a function handle_queue that gets the functions from the queue and calls them, in FIFO order. Commands are issued from the controller by calling a new function in the Gateway class, set_child_value. This function calls the fill_queue function and puts the other set_child_value function from the Sensor class with correct arguments to the queue. I also changed the Sensor class set function to return a set message. The new set_child_value function in the Gateway class is for convenience.

When testing this branch I encountered problems when reconnecting to the Serial interface. My guess is that this has to do with pyserial 2.7 and onwards. Testing with pyserial 2.5 worked flawlessly as far as I could tell. Therefore I changed the required version of pyserial to 2.5. Since this problem might not effect everyone, it can be discussed if it's really a good idea to downgrade pyserial. There seems to be at least some other people that are having similar issues, if looking at pyserial repo. Maybe this part of my pull request should be removed?

The following points are a summary of my changes in the pull request.

* Add queue as attribute to Gateway class
* Add fill_queue function in Gateway class for putting functions in the
    queue.
* Add handle_queue function in Gateway class for getting functions from
    the queue, and calling them.
* Add set_child_value function in Gateway class as a convenience
    function. It will set a new value for a child and send the
    corresponding Message from the gateway to the child's node.
    This is not done directly but by putting a function with arguments to
    the FIFO queue. The function in the queue is the set_child_value
    function in the Sensor class.
* Change set_child_value function in Sensor class to return a set
    Message.
* Change the loop in the run function in SerialGateway class to handle
    queue first, then read from serial interface. If valid input is
    read from serial and decoded, add logic function with input as
    argument to the queue.
* Add some debug logging to SerialGateway class.
* Fix some minor PEP8 issues.
* Fix problem of reading garbage after disconnecting and reconnecting,
    by changing pyserial required version to 2.5 or less.
* Make serial connecting and disconnecting more robust, by sleeping for
    a while after connecting, and by checking if connection is open
    after connecting, and by closing connection when thread stops.
* Add more logging to serial connection functions.
* Change lowest logging level for log messages to INFO (home-assistant uses INFO as lowest).
* Add function to set log level to debug if debug attribute of gateway
    is true.
* Fix logging calls to use proper parameters instead of string
    formatting.
* Add function docstrings to fill_queue, handle_queue and
    set_child_value functions in Gateway class.

As in my previous pull request, I've put the base branch to dev for merging. I don't know if that's what you would like, or if it should be the master branch, if you decide to merge this.

Best regards,
Martin