### PR TITLE
Add threading.lock for send function

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -23,6 +23,7 @@ class Gateway(object):
     def __init__(self, event_callback=None, persistence=False,
                  persistence_file="mysensors.pickle", protocol_version="1.4"):
         self.queue = Queue()
+        self.lock = threading.Lock()
         self.event_callback = event_callback
         self.sensors = {}
         self.metric = True   # if true - use metric, if false - use imperial
@@ -339,7 +340,9 @@ class SerialGateway(Gateway, threading.Thread):
 
     def send(self, message):
         """ Writes a Message to the gateway. """
-        self.serial.write(message.encode())
+        # Lock to make sure only one thread writes at a time to serial port.
+        with self.lock:
+            self.serial.write(message.encode())
 
 
 class Sensor:


### PR DESCRIPTION
This feature will make send function thread safe. It enables
multiple threads at the same time to use the send function, which
writes to the serial port, without risking a conflict at write time.

* Add threading.lock as attribute to Gateway class.
* Use with statement for lock.