### PR TITLE
Remove sleep in connect function

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -276,7 +276,6 @@ class SerialGateway(Gateway, threading.Thread):
             LOGGER.info('Trying to connect to %s', self.port)
             self.serial = serial.Serial(self.port, self.baud,
                                         timeout=self.timeout)
-            time.sleep(3)
             if self.serial.isOpen():
                 LOGGER.info('%s is open...', self.serial.name)
                 LOGGER.info('Connected to %s', self.port)


### PR DESCRIPTION
No obvious benefit has been seen, in tests, in sleeping for 3 seconds
after connecting to gateway via serial port.

* Remove time.sleep(3) in SerialGateway.connect().
* I initially added this wait period to try to avoid reading from the gateway serial port too early, which possibly could give bad bytes. Further testing hasn't shown any evidence of this wait solving that problem.