### PR TITLE
Fix PEP issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,14 @@
+"""Example for using pymysensors."""
 import mysensors.mysensors as mysensors
 
 
-def event(type, nid):
-    print(type + " " + str(nid))
+def event(update_type, nid):
+    """Callback for mysensors updates."""
+    print(update_type + " " + str(nid))
 
-gw = mysensors.SerialGateway('/dev/ttyACM0', event, True)
-gw.debug = True
-gw.start()
+GATEWAY = mysensors.SerialGateway('/dev/ttyACM0', event, True)
+GATEWAY.debug = True
+GATEWAY.start()
 # To set sensor 2, child 1, sub-type V_LIGHT (= 2), with value 1.
-gw.set_child_value(2, 1, 2, 1)
-gw.stop()
+GATEWAY.set_child_value(1, 1, 2, 1)
+GATEWAY.stop()

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -1,3 +1,1 @@
-"""
-Python implementation of MySensors API
-"""
+"""Python implementation of MySensors API."""

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -1,11 +1,10 @@
-"""
-MySensors Constants
-"""
+"""MySensors constants for version 1.4 of MySensors."""
 from enum import IntEnum
 
 
 class MessageType(IntEnum):
-    """ MySensors message types """
+    """MySensors message types."""
+
     # pylint: disable=too-few-public-methods
     presentation = 0        # sent by a node when presenting attached sensors
     set = 1                 # sent from/to sensor when value should be updated
@@ -15,7 +14,8 @@ class MessageType(IntEnum):
 
 
 class Presentation(IntEnum):
-    """ MySensors presentation sub-types """
+    """MySensors presentation sub-types."""
+
     # pylint: disable=too-few-public-methods
     S_DOOR = 0                  # Door and window sensors
     S_MOTION = 1                # Motion sensors
@@ -46,7 +46,8 @@ class Presentation(IntEnum):
 
 
 class SetReq(IntEnum):
-    """ MySensors set/req sub-types """
+    """MySensors set/req sub-types."""
+
     # pylint: disable=too-few-public-methods
     V_TEMP = 0              # Temperature
     V_HUM = 1               # Humidity
@@ -96,7 +97,8 @@ class SetReq(IntEnum):
 
 
 class Internal(IntEnum):
-    """ MySensors internal sub-types """
+    """MySensors internal sub-types."""
+
     # pylint: disable=too-few-public-methods
     # Use this to report the battery level (in percent 0-100).
     I_BATTERY_LEVEL = 0

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -1,11 +1,10 @@
-"""
-MySensors Constants
-"""
+"""MySensors constants for version 1.5 of MySensors."""
 from enum import IntEnum
 
 
 class MessageType(IntEnum):
-    """ MySensors message types """
+    """MySensors message types."""
+
     # pylint: disable=too-few-public-methods
     presentation = 0        # sent by a node when presenting attached sensors
     set = 1                 # sent from/to sensor when value should be updated
@@ -15,7 +14,8 @@ class MessageType(IntEnum):
 
 
 class Presentation(IntEnum):
-    """ MySensors presentation sub-types """
+    """MySensors presentation sub-types."""
+
     # pylint: disable=too-few-public-methods
     S_DOOR = 0                      # Door and window sensors
     S_MOTION = 1                    # Motion sensors
@@ -45,7 +45,8 @@ class Presentation(IntEnum):
     S_DUST = 24                     # Dust level sensor
     S_SCENE_CONTROLLER = 25         # Scene controller device
     S_RGB_LIGHT = 26                # RGB light
-    S_RGBW_LIGHT = 27               # RGBW light (with separate white component)
+    # RGBW light (with separate white component)
+    S_RGBW_LIGHT = 27
     S_COLOR_SENSOR = 28             # Color sensor
     S_HVAC = 29                     # Thermostat/HVAC device
     S_MULTIMETER = 30               # Multimeter device
@@ -55,15 +56,19 @@ class Presentation(IntEnum):
     S_VIBRATION = 34                # Vibration sensor
     S_MOISTURE = 35                 # Moisture sensor
 
+
 class SetReq(IntEnum):
-    """ MySensors set/req sub-types """
+    """MySensors set/req sub-types."""
+
     # pylint: disable=too-few-public-methods
     V_TEMP = 0              # Temperature
     V_HUM = 1               # Humidity
     V_STATUS = 2            # Binary status, 0=off, 1=on
-    V_LIGHT = 2             # Deprecated. Alias for V_STATUS. Light Status.0=off 1=on
+    # Deprecated. Alias for V_STATUS. Light Status.0=off 1=on
+    V_LIGHT = 2
     V_PERCENTAGE = 3        # Percentage value. 0-100 (%)
-    V_DIMMER = 3            # Deprecated. Alias for V_PERCENTAGE. Dimmer value. 0-100 (%)
+    # Deprecated. Alias for V_PERCENTAGE. Dimmer value. 0-100 (%)
+    V_DIMMER = 3
     V_PRESSURE = 4          # Atmospheric Pressure
     # Weather forecast. One of "stable", "sunny", "cloudy", "unstable",
     # "thunderstorm" or "unknown"
@@ -87,8 +92,10 @@ class SetReq(IntEnum):
     V_SCENE_OFF = 20            # Turn of a scene
     # Mode of header. One of "Off", "HeatOn", "CoolOn", or "AutoChangeOver"
     V_HVAC_FLOW_STATE = 21
-    V_HVAC_SPEED = 22           # HVAC/Heater fan speed ("Min", "Normal", "Max", "Auto")
-    V_LIGHT_LEVEL = 23          # Uncalibrated light level. 0-100%. Use V_LEVEL for light level in lux.
+    # HVAC/Heater fan speed ("Min", "Normal", "Max", "Auto")
+    V_HVAC_SPEED = 22
+    # Uncalibrated light level. 0-100%. Use V_LEVEL for light level in lux.
+    V_LIGHT_LEVEL = 23
     V_VAR1 = 24                 # Custom value
     V_VAR2 = 25                 # Custom value
     V_VAR3 = 26                 # Custom value
@@ -105,19 +112,26 @@ class SetReq(IntEnum):
     V_LEVEL = 37                # Used for sending level-value
     V_VOLTAGE = 38              # Voltage level
     V_CURRENT = 39              # Current level
-    V_RGB = 40                  # RGB value transmitted as ASCII hex string (I.e "ff0000" for red)
-    V_RGBW = 41                 # RGBW value transmitted as ASCII hex string (I.e "ff0000ff" for red + full white)
-    V_ID = 42                   # Optional unique sensor id (e.g. OneWire DS1820b ids)
-    # Allows sensors to send in a string representing the unit prefix to be displayed in GUI.
+    # RGB value transmitted as ASCII hex string (I.e "ff0000" for red)
+    V_RGB = 40
+    # RGBW value transmitted as ASCII hex string (I.e "ff0000ff" for red +
+    # full white)
+    V_RGBW = 41
+    # Optional unique sensor id (e.g. OneWire DS1820b ids)
+    V_ID = 42
+    # Allows sensors to send in a string representing the unit prefix to be
+    # displayed in GUI.
     # This is not parsed by controller! E.g. cm, m, km, inch.
     V_UNIT_PREFIX = 43
     V_HVAC_SETPOINT_COOL = 44   # HVAC cold setpoint (Integer between 0-100)
     V_HVAC_SETPOINT_HEAT = 45   # HVAC/Heater setpoint (Integer between 0-100)
-    V_HVAC_FLOW_MODE = 45       # Flow mode for HVAC ("Auto", "ContinuousOn", "PeriodicOn")
+    # Flow mode for HVAC ("Auto", "ContinuousOn", "PeriodicOn")
+    V_HVAC_FLOW_MODE = 45
 
 
 class Internal(IntEnum):
-    """ MySensors internal sub-types """
+    """MySensors internal sub-types."""
+
     # pylint: disable=too-few-public-methods
     # Use this to report the battery level (in percent 0-100).
     I_BATTERY_LEVEL = 0

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -1,7 +1,4 @@
-"""
-pymysensors - Python implementation of the MySensors SerialGateway
-"""
-import serial
+"""pymysensors - Python implementation of the MySensors SerialGateway."""
 import time
 import threading
 import logging
@@ -9,41 +6,38 @@ import pickle
 import os
 import json
 from queue import Queue
-
-# Correct versions will be dynamically imported when creating a gateway
-global Internal, MessageType
+from importlib import import_module
+import serial
 
 LOGGER = logging.getLogger(__name__)
 
 
 class Gateway(object):
+    """Base implementation for a MySensors Gateway."""
 
-    """ Base implementation for a MySensors Gateway. """
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, event_callback=None, persistence=False,
-                 persistence_file="mysensors.pickle", protocol_version="1.4"):
+                 persistence_file='mysensors.pickle', protocol_version='1.4'):
+        """Setup Gateway."""
         self.queue = Queue()
         self.lock = threading.Lock()
         self.event_callback = event_callback
         self.sensors = {}
-        self.metric = True   # if true - use metric, if false - use imperial
-        self.debug = False   # if true - print all received messages
+        self.metric = True  # if true - use metric, if false - use imperial
+        self.debug = False  # if true - print all received messages
         self.persistence = persistence  # if true - save sensors to disk
-        self.persistence_file = persistence_file    # path to persistence file
+        self.persistence_file = persistence_file  # path to persistence file
         if persistence:
             self._load_sensors()
-        if protocol_version == "1.4":
-            _const = __import__("mysensors.const_14", globals(), locals(),
-                                ['Internal', 'MessageType'], 0)
-        elif protocol_version == "1.5":
-            _const = __import__("mysensors.const_15", globals(), locals(),
-                                ['Internal', 'MessageType'], 0)
-        global Internal, MessageType
-        Internal = _const.Internal
-        MessageType = _const.MessageType
+        if protocol_version == '1.4':
+            _const = import_module('mysensors.const_14')
+        elif protocol_version == '1.5':
+            _const = import_module('mysensors.const_15')
+        self.const = _const
 
     def _handle_presentation(self, msg):
-        """ Processes a presentation message. """
+        """Process a presentation message."""
         if msg.child_id == 255:
             # this is a presentation of the sensor platform
             self.add_sensor(msg.node_id)
@@ -57,36 +51,36 @@ class Gateway(object):
             self.alert(msg.node_id)
 
     def _handle_set(self, msg):
-        """ Processes a set message. """
+        """Process a set message."""
         if self.is_sensor(msg.node_id, msg.child_id):
             self.sensors[msg.node_id].set_child_value(
                 msg.child_id, msg.sub_type, msg.payload)
             self.alert(msg.node_id)
 
     def _handle_internal(self, msg):
-        """ Processes an internal protocol message. """
-        if msg.sub_type == Internal.I_ID_REQUEST:
+        """Process an internal protocol message."""
+        if msg.sub_type == self.const.Internal.I_ID_REQUEST:
             return msg.copy(ack=0,
-                            sub_type=Internal.I_ID_RESPONSE,
+                            sub_type=self.const.Internal.I_ID_RESPONSE,
                             payload=self.add_sensor())
-        elif msg.sub_type == Internal.I_SKETCH_NAME:
+        elif msg.sub_type == self.const.Internal.I_SKETCH_NAME:
             if self.is_sensor(msg.node_id):
                 self.sensors[msg.node_id].sketch_name = msg.payload
                 self.alert(msg.node_id)
-        elif msg.sub_type == Internal.I_SKETCH_VERSION:
+        elif msg.sub_type == self.const.Internal.I_SKETCH_VERSION:
             if self.is_sensor(msg.node_id):
                 self.sensors[msg.node_id].sketch_version = msg.payload
                 self.alert(msg.node_id)
-        elif msg.sub_type == Internal.I_CONFIG:
+        elif msg.sub_type == self.const.Internal.I_CONFIG:
             return msg.copy(ack=0, payload='M' if self.metric else 'I')
-        elif msg.sub_type == Internal.I_BATTERY_LEVEL:
+        elif msg.sub_type == self.const.Internal.I_BATTERY_LEVEL:
             if self.is_sensor(msg.node_id):
                 self.sensors[msg.node_id].battery_level = int(msg.payload)
                 self.alert(msg.node_id)
-        elif msg.sub_type == Internal.I_TIME:
+        elif msg.sub_type == self.const.Internal.I_TIME:
             return msg.copy(ack=0, payload=int(time.time()))
-        elif msg.sub_type == Internal.I_LOG_MESSAGE and self.debug:
-            LOGGER.info("n:%s c:%s t:%s s:%s p:%s",
+        elif msg.sub_type == self.const.Internal.I_LOG_MESSAGE and self.debug:
+            LOGGER.info('n:%s c:%s t:%s s:%s p:%s',
                         msg.node_id,
                         msg.child_id,
                         msg.type,
@@ -94,50 +88,50 @@ class Gateway(object):
                         msg.payload)
 
     def send(self, message):
-        """ Should be implemented by a child class. """
-        pass
+        """Should be implemented by a child class."""
+        raise NotImplementedError
 
     def logic(self, data):
-        """
-        Parse the data and respond to it appropriately.
+        """Parse the data and respond to it appropriately.
+
         Response is returned to the caller and has to be sent
-        data is a mysensors command string
+        data as a mysensors command string.
         """
         msg = Message(data)
 
-        if msg.type == MessageType.presentation:
+        if msg.type == self.const.MessageType.presentation:
             self._handle_presentation(msg)
-        elif msg.type == MessageType.set:
+        elif msg.type == self.const.MessageType.set:
             self._handle_set(msg)
-        elif msg.type == MessageType.internal:
+        elif msg.type == self.const.MessageType.internal:
             return self._handle_internal(msg)
         return None
 
     def _save_pickle(self, filename):
-        """ Save sensors to pickle file """
-        with open(filename, 'wb') as f:
-            pickle.dump(self.sensors, f, pickle.HIGHEST_PROTOCOL)
+        """Save sensors to pickle file."""
+        with open(filename, 'wb') as file_handle:
+            pickle.dump(self.sensors, file_handle, pickle.HIGHEST_PROTOCOL)
 
     def _load_pickle(self, filename):
-        """ Load sensors from pickle file """
+        """Load sensors from pickle file."""
         try:
-            with open(filename, 'rb') as f:
-                self.sensors = pickle.load(f)
+            with open(filename, 'rb') as file_handle:
+                self.sensors = pickle.load(file_handle)
         except IOError:
             pass
 
     def _save_json(self, filename):
-        """ Save sensors to json file """
-        with open(filename, 'w') as f:
-            json.dump(self.sensors, f, cls=MySensorsJSONEncoder)
+        """Save sensors to json file."""
+        with open(filename, 'w') as file_handle:
+            json.dump(self.sensors, file_handle, cls=MySensorsJSONEncoder)
 
     def _load_json(self, filename):
-        """ Load sensors from json file """
-        with open(filename, 'r') as f:
-            self.sensors = json.load(f, cls=MySensorsJSONDecoder)
+        """Load sensors from json file."""
+        with open(filename, 'r') as file_handle:
+            self.sensors = json.load(file_handle, cls=MySensorsJSONDecoder)
 
     def _save_sensors(self):
-        """ Save sensors to file """
+        """Save sensors to file."""
         fname = os.path.realpath(self.persistence_file)
         exists = os.path.isfile(fname)
         dirname = os.path.dirname(fname)
@@ -148,7 +142,7 @@ class Gateway(object):
             LOGGER.info('Permission denied when writing to %s', fname)
 
     def _load_sensors(self):
-        """ Load sensors from file """
+        """Load sensors from file."""
         exists = os.path.isfile(self.persistence_file)
         if exists and os.access(self.persistence_file, os.R_OK):
             self._perform_file_action(self.persistence_file, 'load')
@@ -157,29 +151,30 @@ class Gateway(object):
                         'readable: %s', self.persistence_file)
 
     def _perform_file_action(self, filename, action):
-        """
+        """Perform action on specific file types.
+
         Dynamic dispatch function for performing actions on
         specific file types.
         """
-        path, ext = os.path.splitext(filename)
-        fn = getattr(self, '_%s_%s' % (action, ext[1:]), None)
-        if fn is None:
+        ext = os.path.splitext(filename)[1]
+        func = getattr(self, '_%s_%s' % (action, ext[1:]), None)
+        if func is None:
             raise Exception('Unsupported file type %s' % ext[1:])
-        fn(filename)
+        func(filename)
 
     def alert(self, nid):
-        """
-        Tell anyone who wants to know that a sensor was updated. Also save
-        sensors if persistence is enabled
+        """Tell anyone who wants to know that a sensor was updated.
+
+        Also save sensors if persistence is enabled.
         """
         if self.event_callback is not None:
-            self.event_callback("sensor_update", nid)
+            self.event_callback('sensor_update', nid)
 
         if self.persistence:
             self._save_sensors()
 
     def _get_next_id(self):
-        """ Returns the next available sensor id. """
+        """Return the next available sensor id."""
         if len(self.sensors):
             next_id = max(self.sensors.keys()) + 1
         else:
@@ -189,7 +184,7 @@ class Gateway(object):
         return None
 
     def add_sensor(self, sensorid=None):
-        """ Adds a sensor to the gateway. """
+        """Add a sensor to the gateway."""
         if sensorid is None:
             sensorid = self._get_next_id()
 
@@ -199,7 +194,7 @@ class Gateway(object):
         return None
 
     def is_sensor(self, sensorid, child_id=None):
-        """ Returns True if a sensor and its child exists. """
+        """Return True if a sensor and its child exist."""
         if sensorid not in self.sensors:
             return False
         if child_id is not None:
@@ -207,12 +202,13 @@ class Gateway(object):
         return True
 
     def setup_logging(self):
-        """ Sets the logging level to debug. """
+        """Set the logging level to debug."""
         if self.debug:
             logging.basicConfig(level=logging.DEBUG)
 
     def handle_queue(self, queue=None):
-        """
+        """Handle queue.
+
         If queue is not empty, get the function and any args and kwargs
         from the queue. Run the function and return output.
         """
@@ -226,7 +222,8 @@ class Gateway(object):
         return None
 
     def fill_queue(self, func, args=None, kwargs=None, queue=None):
-        """
+        """Put a function in a queue.
+
         Put the function 'func', a tuple of arguments 'args' and a dict
         of keyword arguments 'kwargs', as a tuple in the queue.
         """
@@ -239,24 +236,26 @@ class Gateway(object):
         queue.put((func, args, kwargs))
 
     def set_child_value(self, sensor_id, child_id, value_type, value):
-        """
-        Add a command to set a sensor value, to the queue.
+        """Add a command to set a sensor value, to the queue.
+
         A queued command will be sent to the sensor, when the gateway
         thread has sent all previously queued commands to the FIFO queue.
         """
-        self.fill_queue(self.sensors[sensor_id].set_child_value,
-                        (child_id, value_type, value))
+        if self.is_sensor(sensor_id, child_id):
+            self.fill_queue(self.sensors[sensor_id].set_child_value,
+                            (child_id, value_type, value))
 
 
 class SerialGateway(Gateway, threading.Thread):
+    """Serial gateway for MySensors."""
 
-    """ MySensors serial gateway. """
     # pylint: disable=too-many-arguments
 
     def __init__(self, port, event_callback=None,
-                 persistence=False, persistence_file="mysensors.pickle",
-                 protocol_version="1.4", baud=115200, timeout=1.0,
+                 persistence=False, persistence_file='mysensors.pickle',
+                 protocol_version='1.4', baud=115200, timeout=1.0,
                  reconnect_timeout=10.0):
+        """Setup serial gateway."""
         threading.Thread.__init__(self)
         Gateway.__init__(self, event_callback, persistence,
                          persistence_file, protocol_version)
@@ -268,7 +267,7 @@ class SerialGateway(Gateway, threading.Thread):
         self._stop_event = threading.Event()
 
     def connect(self):
-        """ Connects to the serial port. """
+        """Connect to the serial port."""
         if self.serial:
             LOGGER.info('Already connected to %s', self.port)
             return True
@@ -291,20 +290,20 @@ class SerialGateway(Gateway, threading.Thread):
         return True
 
     def disconnect(self):
-        """ Disconnects from the serial port. """
+        """Disconnect from the serial port."""
         if self.serial is not None:
             LOGGER.info('Disconnecting from %s', self.serial.name)
             self.serial.close()
             self.serial = None
 
     def stop(self):
-        """ Stops the background thread. """
+        """Stop the background thread."""
         self.disconnect()
         LOGGER.info('Stopping thread')
         self._stop_event.set()
 
     def run(self):
-        """ Background thread that reads messages from the gateway. """
+        """Background thread that reads messages from the gateway."""
         self.setup_logging()
         while not self._stop_event.is_set():
             if self.serial is None and not self.connect():
@@ -345,31 +344,31 @@ class SerialGateway(Gateway, threading.Thread):
                 continue
 
     def send(self, message):
-        """ Writes a Message to the gateway. """
+        """Write a Message to the gateway."""
         # Lock to make sure only one thread writes at a time to serial port.
         with self.lock:
             self.serial.write(message.encode())
 
 
 class Sensor:
-
-    """ Represents a sensor. """
+    """Represent a sensor."""
 
     def __init__(self, sensor_id):
+        """Setup sensor."""
         self.sensor_id = sensor_id
         self.children = {}
         self.type = None
         self.sketch_name = None
         self.sketch_version = None
         self.battery_level = 0
-        self.protocol_version = None  # Add missing attribute
+        self.protocol_version = None
 
     def add_child_sensor(self, child_id, child_type):
-        """ Creates and adds a child sensor. """
+        """Create and add a child sensor."""
         self.children[child_id] = ChildSensor(child_id, child_type)
 
     def set_child_value(self, child_id, value_type, value):
-        """ Sets a child sensor's value. """
+        """Set a child sensor's value."""
         if child_id in self.children:
             self.children[child_id].values[value_type] = value
             msg = Message()
@@ -381,42 +380,41 @@ class Sensor:
 
 
 class ChildSensor:
+    """Represent a child sensor."""
 
-    """ Represents a child sensor. """
     # pylint: disable=too-few-public-methods
 
     def __init__(self, child_id, child_type):
+        """Setup child sensor."""
+        # pylint: disable=invalid-name
         self.id = child_id
         self.type = child_type
         self.values = {}
 
 
 class Message:
-
-    """ Represents a message from the gateway. """
+    """Represent a message from the gateway."""
 
     def __init__(self, data=None):
+        """Setup message."""
         self.node_id = 0
         self.child_id = 0
         self.type = 0
         self.ack = 0
         self.sub_type = 0
-        self.payload = ""  # All data except payload are integers
+        self.payload = ''  # All data except payload are integers
         if data is not None:
             self.decode(data)
 
     def copy(self, **kwargs):
-        """
-        Copies a message, optionally replacing attributes with keyword
-        arguments.
-        """
+        """Copy a message, optionally replace attributes with kwargs."""
         msg = Message(self.encode())
         for key, val in kwargs.items():
             setattr(msg, key, val)
         return msg
 
     def decode(self, data):
-        """ Decode a message from command string. """
+        """Decode a message from command string."""
         data = data.rstrip().split(';')
         self.payload = data.pop()
         (self.node_id,
@@ -426,54 +424,59 @@ class Message:
          self.sub_type) = [int(f) for f in data]
 
     def encode(self):
-        """ Encode a command string from message. """
-        return ";".join([str(f) for f in [
+        """Encode a command string from message."""
+        return ';'.join([str(f) for f in [
             self.node_id,
             self.child_id,
             int(self.type),
             self.ack,
             int(self.sub_type),
             self.payload,
-        ]]) + "\n"
+        ]]) + '\n'
 
 
 class MySensorsJSONEncoder(json.JSONEncoder):
+    """JSON encoder."""
 
-    def default(self, o):
-        if isinstance(o, Sensor):
+    def default(self, obj):  # pylint: disable=E0202
+        """Serialize obj into JSON."""
+        if isinstance(obj, Sensor):
             return {
-                'sensor_id': o.sensor_id,
-                'children': o.children,
-                'type': o.type,
-                'sketch_name': o.sketch_name,
-                'sketch_version': o.sketch_version,
-                'battery_level': o.battery_level,
+                'sensor_id': obj.sensor_id,
+                'children': obj.children,
+                'type': obj.type,
+                'sketch_name': obj.sketch_name,
+                'sketch_version': obj.sketch_version,
+                'battery_level': obj.battery_level,
             }
-        if isinstance(o, ChildSensor):
+        if isinstance(obj, ChildSensor):
             return {
-                'id': o.id,
-                'type': o.type,
-                'values': o.values,
+                'id': obj.id,
+                'type': obj.type,
+                'values': obj.values,
             }
-        return json.JSONEncoder.default(self, o)
+        return json.JSONEncoder.default(self, obj)
 
 
 class MySensorsJSONDecoder(json.JSONDecoder):
+    """JSON decoder."""
 
     def __init__(self):
+        """Setup decoder."""
         json.JSONDecoder.__init__(self, object_hook=self.dict_to_object)
 
-    def dict_to_object(self, o):
-        if not isinstance(o, dict):
-            return o
-        if 'sensor_id' in o:
-            sensor = Sensor(o['sensor_id'])
-            sensor.__dict__.update(o)
+    def dict_to_object(self, obj):  # pylint: disable=R0201
+        """Return object from dict."""
+        if not isinstance(obj, dict):
+            return obj
+        if 'sensor_id' in obj:
+            sensor = Sensor(obj['sensor_id'])
+            sensor.__dict__.update(obj)
             return sensor
-        elif all(k in o for k in ['id', 'type', 'values']):
-            child = ChildSensor(o['id'], o['type'])
-            child.values = o['values']
+        elif all(k in obj for k in ['id', 'type', 'values']):
+            child = ChildSensor(obj['id'], obj['type'])
+            child.values = obj['values']
             return child
-        elif all(k.isdigit() for k in o.keys()):
-            return {int(k): v for k, v in o.items()}
-        return o
+        elif all(k.isdigit() for k in obj.keys()):
+            return {int(k): v for k, v in obj.items()}
+        return obj

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""Setup file for mysensors package."""
 from setuptools import setup
 
 setup(name='pymysensors',

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,3 +1,4 @@
+"""Test mysensors with unittest."""
 import unittest
 from unittest.mock import patch
 
@@ -6,159 +7,177 @@ from mysensors.const_14 import MessageType, Internal, Presentation, SetReq
 
 
 class TestGateway(unittest.TestCase):
-
-    """ Test the Gateway logic function """
+    """Test the Gateway logic function."""
 
     def setUp(self):
-        self.gw = my.Gateway()
+        """Setup gateway."""
+        self.gateway = my.Gateway()
 
     def _add_sensor(self, sensorid):
-        self.gw.sensors[sensorid] = my.Sensor(sensorid)
-        return self.gw.sensors[sensorid]
+        """Add sensor node. Return sensor node instance."""
+        self.gateway.sensors[sensorid] = my.Sensor(sensorid)
+        return self.gateway.sensors[sensorid]
 
     def test_non_presented_sensor(self):
-        self.gw.logic("1;0;1;0;23;43\n")
-        self.assertNotIn(1, self.gw.sensors)
+        """Test non presented sensor node."""
+        self.gateway.logic('1;0;1;0;23;43\n')
+        self.assertNotIn(1, self.gateway.sensors)
 
-        self.gw.logic("1;1;1;0;1;75\n")
-        self.assertNotIn(1, self.gw.sensors)
+        self.gateway.logic('1;1;1;0;1;75\n')
+        self.assertNotIn(1, self.gateway.sensors)
 
-        self.gw.logic("1;255;3;0;0;79\n")
-        self.assertNotIn(1, self.gw.sensors)
+        self.gateway.logic('1;255;3;0;0;79\n')
+        self.assertNotIn(1, self.gateway.sensors)
 
     def test_internal_id_request(self):
-        ret = self.gw.logic("255;255;3;0;3;\n")
-        self.assertEqual(ret.encode(), "255;255;3;0;4;1\n")
-        self.assertIn(1, self.gw.sensors)
+        """Test internal node id request."""
+        ret = self.gateway.logic('255;255;3;0;3;\n')
+        self.assertEqual(ret.encode(), '255;255;3;0;4;1\n')
+        self.assertIn(1, self.gateway.sensors)
 
-    def test_presenation_arduino_node(self):
+    def test_presentation_arduino_node(self):
+        """Test presentation of sensor node."""
         sensor = self._add_sensor(1)
-        self.gw.logic("1;255;0;0;17;1.4.1\n")
+        self.gateway.logic('1;255;0;0;17;1.4.1\n')
         self.assertEqual(sensor.type, Presentation.S_ARDUINO_NODE)
-        self.assertEqual(sensor.protocol_version, "1.4.1")
+        self.assertEqual(sensor.protocol_version, '1.4.1')
 
     def test_internal_config(self):
+        """Test internal config request, metric or imperial."""
         # metric
-        ret = self.gw.logic("1;255;3;0;6;0\n")
-        self.assertEqual(ret.encode(), "1;255;3;0;6;M\n")
+        ret = self.gateway.logic('1;255;3;0;6;0\n')
+        self.assertEqual(ret.encode(), '1;255;3;0;6;M\n')
         # imperial
-        self.gw.metric = False
-        ret = self.gw.logic("1;255;3;0;6;0\n")
-        self.assertEqual(ret.encode(), "1;255;3;0;6;I\n")
+        self.gateway.metric = False
+        ret = self.gateway.logic('1;255;3;0;6;0\n')
+        self.assertEqual(ret.encode(), '1;255;3;0;6;I\n')
 
     def test_internal_time(self):
+        """Test internal time request."""
         self._add_sensor(1)
         with patch('mysensors.mysensors.time') as mock_time:
             mock_time.time.return_value = 123456789
-            ret = self.gw.logic("1;255;3;0;1;\n")
-            self.assertEqual(ret.encode(), "1;255;3;0;1;123456789\n")
+            ret = self.gateway.logic('1;255;3;0;1;\n')
+            self.assertEqual(ret.encode(), '1;255;3;0;1;123456789\n')
 
     def test_internal_sketch_name(self):
+        """Test internal receive of sketch name."""
         sensor = self._add_sensor(1)
-        self.gw.logic("1;255;3;0;11;lighthum demo sens\n")
-        self.assertEqual(sensor.sketch_name, "lighthum demo sens")
+        self.gateway.logic('1;255;3;0;11;lighthum demo sens\n')
+        self.assertEqual(sensor.sketch_name, 'lighthum demo sens')
 
     def test_internal_sketch_version(self):
+        """Test internal receive of sketch version."""
         sensor = self._add_sensor(1)
-        self.gw.logic("1;255;3;0;12;1.0\n")
-        self.assertEqual(sensor.sketch_version, "1.0")
+        self.gateway.logic('1;255;3;0;12;1.0\n')
+        self.assertEqual(sensor.sketch_version, '1.0')
 
-    def test_presenation_light_level_sensor(self):
+    def test_present_light_level_sensor(self):
+        """Test presentation of a light level sensor."""
         sensor = self._add_sensor(1)
-        self.gw.logic("1;0;0;0;16;1.4.1\n")
+        self.gateway.logic('1;0;0;0;16;\n')
         self.assertIn(0, sensor.children)
         self.assertEqual(sensor.children[0].type, Presentation.S_LIGHT_LEVEL)
 
-    def test_presentation_humidity_sensor(self):
+    def test_present_humidity_sensor(self):
+        """Test presentation of a humidity sensor."""
         sensor = self._add_sensor(1)
-        self.gw.logic("1;0;0;0;7;1.4.1\n")
+        self.gateway.logic('1;0;0;0;7;\n')
         self.assertEqual(0 in sensor.children, True)
         self.assertEqual(sensor.children[0].type, Presentation.S_HUM)
 
     def test_set_light_level(self):
+        """Test set of light level."""
         sensor = self._add_sensor(1)
         sensor.children[0] = my.ChildSensor(0, Presentation.S_LIGHT_LEVEL)
-        self.gw.logic("1;0;1;0;23;43\n")
+        self.gateway.logic('1;0;1;0;23;43\n')
         self.assertEqual(sensor.children[0].values[SetReq.V_LIGHT_LEVEL], '43')
 
-    def test_humidity_level(self):
+    def test_set_humidity_level(self):
+        """Test set humidity level."""
         sensor = self._add_sensor(1)
         sensor.children[1] = my.ChildSensor(1, Presentation.S_HUM)
-        self.gw.logic("1;1;1;0;1;75\n")
+        self.gateway.logic('1;1;1;0;1;75\n')
         self.assertEqual(sensor.children[1].values[SetReq.V_HUM], '75')
 
     def test_battery_level(self):
+        """Test internal receive of battery level."""
         sensor = self._add_sensor(1)
-        self.gw.logic("1;255;3;0;0;79\n")
+        self.gateway.logic('1;255;3;0;0;79\n')
         self.assertEqual(sensor.battery_level, 79)
 
     def test_persistence(self):
+        """Test persistence using pickle."""
         self._add_sensor(1)
-        self.gw.sensors[1].type = Presentation.S_ARDUINO_NODE
-        self.gw.sensors[1].sketch_name = "testsketch"
-        self.gw.sensors[1].sketch_version = "1.0"
-        self.gw.sensors[1].battery_level = 78
+        self.gateway.sensors[1].type = Presentation.S_ARDUINO_NODE
+        self.gateway.sensors[1].sketch_name = 'testsketch'
+        self.gateway.sensors[1].sketch_version = '1.0'
+        self.gateway.sensors[1].battery_level = 78
 
-        sensor = self.gw.sensors[1]
-        self.gw.persistence_file = "persistence.file.pickle"
-        self.gw._save_sensors()
-        del self.gw.sensors[1]
-        self.gw._load_sensors()
-        self.assertEqual(self.gw.sensors[1].sketch_name, sensor.sketch_name)
-        self.assertEqual(self.gw.sensors[1].sketch_version,
+        sensor = self.gateway.sensors[1]
+        self.gateway.persistence_file = 'persistence.file.pickle'
+        self.gateway._save_sensors()  # pylint: disable=protected-access
+        del self.gateway.sensors[1]
+        self.gateway._load_sensors()  # pylint: disable=protected-access
+        self.assertEqual(
+            self.gateway.sensors[1].sketch_name, sensor.sketch_name)
+        self.assertEqual(self.gateway.sensors[1].sketch_version,
                          sensor.sketch_version)
         self.assertEqual(
-            self.gw.sensors[1].battery_level, sensor.battery_level)
-        self.assertEqual(self.gw.sensors[1].type, sensor.type)
+            self.gateway.sensors[1].battery_level, sensor.battery_level)
+        self.assertEqual(self.gateway.sensors[1].type, sensor.type)
 
     def test_json_persistence(self):
+        """Test persistence using json."""
         sensor = self._add_sensor(1)
         sensor.children[0] = my.ChildSensor(0, Presentation.S_LIGHT_LEVEL)
-        self.gw.sensors[1].type = Presentation.S_ARDUINO_NODE
-        self.gw.sensors[1].sketch_name = "testsketch"
-        self.gw.sensors[1].sketch_version = "1.0"
-        self.gw.sensors[1].battery_level = 78
+        self.gateway.sensors[1].type = Presentation.S_ARDUINO_NODE
+        self.gateway.sensors[1].sketch_name = 'testsketch'
+        self.gateway.sensors[1].sketch_version = '1.0'
+        self.gateway.sensors[1].battery_level = 78
 
-        sensor = self.gw.sensors[1]
-        self.gw.persistence_file = "persistence.file.json"
-        self.gw._save_sensors()
-        del self.gw.sensors[1]
-        self.gw._load_sensors()
-        self.assertEqual(self.gw.sensors[1].sketch_name, sensor.sketch_name)
-        self.assertEqual(self.gw.sensors[1].sketch_version,
+        sensor = self.gateway.sensors[1]
+        self.gateway.persistence_file = 'persistence.file.json'
+        self.gateway._save_sensors()  # pylint: disable=protected-access
+        del self.gateway.sensors[1]
+        self.gateway._load_sensors()  # pylint: disable=protected-access
+        self.assertEqual(
+            self.gateway.sensors[1].sketch_name, sensor.sketch_name)
+        self.assertEqual(self.gateway.sensors[1].sketch_version,
                          sensor.sketch_version)
         self.assertEqual(
-            self.gw.sensors[1].battery_level, sensor.battery_level)
-        self.assertEqual(self.gw.sensors[1].type, sensor.type)
+            self.gateway.sensors[1].battery_level, sensor.battery_level)
+        self.assertEqual(self.gateway.sensors[1].type, sensor.type)
 
 
 class TestMessage(unittest.TestCase):
-
-    """ Test the Message class and it's encode/decode functions """
+    """Test the Message class and it's encode/decode functions."""
 
     def test_encode(self):
-        m = my.Message()
-        cmd = m.encode()
-        self.assertEqual(cmd, "0;0;0;0;0;\n")
+        """Test encode of message."""
+        msg = my.Message()
+        cmd = msg.encode()
+        self.assertEqual(cmd, '0;0;0;0;0;\n')
 
-        m.node_id = 255
-        m.child_id = 255
-        m.type = MessageType.internal
-        m.sub_type = Internal.I_BATTERY_LEVEL
-        m.ack = 0
-        m.payload = 57
+        msg.node_id = 255
+        msg.child_id = 255
+        msg.type = MessageType.internal
+        msg.sub_type = Internal.I_BATTERY_LEVEL
+        msg.ack = 0
+        msg.payload = 57
 
-        cmd = m.encode()
-        self.assertEqual(cmd, "255;255;3;0;0;57\n")
+        cmd = msg.encode()
+        self.assertEqual(cmd, '255;255;3;0;0;57\n')
 
     def test_decode(self):
-        m = my.Message("255;255;3;0;0;57\n")
-        self.assertEqual(m.node_id, 255)
-        self.assertEqual(m.child_id, 255)
-        self.assertEqual(m.type, MessageType.internal)
-        self.assertEqual(m.sub_type, Internal.I_BATTERY_LEVEL)
-        self.assertEqual(m.ack, 0)
-        self.assertEqual(m.payload, '57')
+        """Test decode of message."""
+        msg = my.Message('255;255;3;0;0;57\n')
+        self.assertEqual(msg.node_id, 255)
+        self.assertEqual(msg.child_id, 255)
+        self.assertEqual(msg.type, MessageType.internal)
+        self.assertEqual(msg.sub_type, Internal.I_BATTERY_LEVEL)
+        self.assertEqual(msg.ack, 0)
+        self.assertEqual(msg.payload, '57')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Fix doc strings in mysensors.py.
* Fix global variable names.
* Fix too short variable names.
* Disable pylint warning for id variable.
* Import the whole const module instead of just some objects.
* Make const an instance attribute of Gateway class.
* Disable pylint message too many instance attributes.
* Disable pylint E0202 for default function in JSONEncoder.
* Disable pylint R0201 for dict_to_object in JSONDecoder.
* Fix docstrings in test.py.
* Fix some short variables in test.py.
* Fix some typos of function names in test.py
* Disable pylint protected access in test.py.
* Remove incorrect payload in presentation message for child sensor
	in test.py.
* Fix only use single quotes except for docstrings.