### PR TITLE
Add TCP ethernet gateway

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ def event(update_type, nid):
     """Callback for mysensors updates."""
     print(update_type + " " + str(nid))
 
+# To create a serial gateway.
 GATEWAY = mysensors.SerialGateway('/dev/ttyACM0', event, True)
+
+# To create a TCP gateway.
+# GATEWAY = mysensors.TCPGateway('127.0.0.1', event, True)
+
 GATEWAY.debug = True
 GATEWAY.start()
 # To set sensor 1, child 1, sub-type V_LIGHT (= 2), with value 1.

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -5,6 +5,8 @@ import logging
 import pickle
 import os
 import json
+import socket
+import select
 from queue import Queue
 from importlib import import_module
 import serial
@@ -347,7 +349,7 @@ class SerialGateway(Gateway, threading.Thread):
                 return False
 
         except serial.SerialException:
-            LOGGER.exception('Unable to connect to %s', self.port)
+            LOGGER.error('Unable to connect to %s', self.port)
             return False
         return True
 
@@ -403,6 +405,160 @@ class SerialGateway(Gateway, threading.Thread):
         # Lock to make sure only one thread writes at a time to serial port.
         with self.lock:
             self.serial.write(message.encode())
+
+
+class TCPGateway(Gateway, threading.Thread):
+    """MySensors TCP ethernet gateway."""
+
+    # pylint: disable=too-many-arguments
+
+    def __init__(self, host, event_callback=None,
+                 persistence=False, persistence_file="mysensors.pickle",
+                 protocol_version="1.4", port=5003, timeout=1.0,
+                 reconnect_timeout=10.0):
+        """Setup TCP ethernet gateway."""
+        threading.Thread.__init__(self)
+        Gateway.__init__(self, event_callback, persistence,
+                         persistence_file, protocol_version)
+        self.sock = None
+        self.server_address = (host, port)
+        self.timeout = timeout
+        self.reconnect_timeout = reconnect_timeout
+        self._stop_event = threading.Event()
+
+    def connect(self):
+        """Connect to the socket object, on host and port."""
+        if self.sock:
+            LOGGER.info('Already connected to %s', self.sock)
+            return True
+        try:
+            # Connect to the server at the port
+            LOGGER.info(
+                'Trying to connect to %s', self.server_address)
+            self.sock = socket.create_connection(
+                self.server_address, self.reconnect_timeout)
+            LOGGER.info('Connected to %s', self.server_address)
+            return True
+
+        except TimeoutError:
+            LOGGER.error(
+                'Connecting to socket timed out for %s.', self.server_address)
+            return False
+        except OSError:
+            LOGGER.error(
+                'Failed to connect to socket at %s.', self.server_address)
+            return False
+
+    def disconnect(self):
+        """Close the socket."""
+        if not self.sock:
+            return
+        LOGGER.info('Closing socket at %s.', self.server_address)
+        self.sock.shutdown(socket.SHUT_WR)
+        self.sock.close()
+        self.sock = None
+        LOGGER.info('Socket closed at %s.', self.server_address)
+
+    def stop(self):
+        """Stop the background thread."""
+        LOGGER.info('Stopping thread')
+        self._stop_event.set()
+
+    def _check_socket(self, sock=None, timeout=None):
+        """Check if socket is readable/writable."""
+        if sock is None:
+            sock = self.sock
+        available_socks = select.select([sock], [sock], [sock], timeout)
+        if available_socks[2]:
+            raise OSError
+        return available_socks
+
+    def recv_timeout(self):
+        """Receive reply from server, with a timeout."""
+        # make socket non blocking
+        self.sock.setblocking(False)
+        # total data in an array
+        total_data = []
+        data_string = ''
+        joined_data = ''
+        # start time
+        begin = time.time()
+
+        while not data_string.endswith('\n'):
+            data_string = ''
+            # break after timeout
+            if time.time() - begin > self.timeout:
+                break
+            # receive data
+            try:
+                # Buffer size from gateway should be 120 bytes
+                # according to mysensors ethernet gateway util.
+                data_bytes = self.sock.recv(120)
+                if data_bytes:
+                    data_string = data_bytes.decode('utf-8')
+                    LOGGER.debug('Received %s', data_string)
+                    total_data.append(data_string)
+                    # reset start time
+                    begin = time.time()
+                    # join all data to final data
+                    joined_data = ''.join(total_data)
+                else:
+                    # sleep to add time difference
+                    time.sleep(0.1)
+            except OSError:
+                LOGGER.error('Receive from server failed.')
+                self.disconnect()
+                break
+            except ValueError:
+                LOGGER.warning(
+                    'Error decoding message from gateway, '
+                    'probably received bad byte.')
+                break
+
+        return joined_data
+
+    def send(self, message):
+        """Write a command string to the gateway via the socket."""
+        if not message:
+            return
+        with self.lock:
+            try:
+                # Send data
+                LOGGER.debug('Sending %s', message)
+                self.sock.sendall(message.encode())
+
+            except OSError:
+                # Send failed
+                LOGGER.error('Send to server failed.')
+                self.disconnect()
+
+    def run(self):
+        """Background thread that reads messages from the gateway."""
+        self.setup_logging()
+        while not self._stop_event.is_set():
+            if self.sock is None and not self.connect():
+                LOGGER.info('Waiting 10 secs before trying to connect again.')
+                time.sleep(self.reconnect_timeout)
+                continue
+            time.sleep(0.02)  # short sleep to avoid burning 100% cpu
+            try:
+                available_socks = self._check_socket()
+            except OSError:
+                LOGGER.error('Server socket %s has an error.', self.sock)
+                self.disconnect()
+                continue
+            if available_socks[1] and self.sock is not None:
+                response = self.handle_queue()
+                if response is not None:
+                    self.send(response.encode())
+            if available_socks[0] and self.sock is not None:
+                string = self.recv_timeout()
+                lines = string.split('\n')
+                # Throw away last empty line or uncompleted message.
+                del lines[-1]
+                for line in lines:
+                    self.fill_queue(self.logic, (line,))
+        self.disconnect()
 
 
 class Sensor:


### PR DESCRIPTION
This adds a gateway class for tcp socket. Arguments to the
class are similar to the serial gateway class. The first argument is a
positional argument called host. Specify the host ip address there. A
keyword argument called port is used for specifying the port of the
connection. The rest of the arguments are named exactly the same and
used in a similar fashion.

* Add TCPGateway child class to Gateway class.
* Use non blocking socket and blocking select.
* Blocking with select should return the socket ready for either
  reading or writing instantly.
* Use socket.SHUT_WR when shutting down socket.
* Update main.py with example of TCP gateway.
* Use socket.create_connection instead of creating the socket
  separately and then connecting it.
* Only handle queue if there's a socket available for writing in
  TCPGateway.
* Use correct socket exceptions.
* Add lock to TCPGateway send method.
* Add short sleep to while loop in run method for TCPGateway class to
  avoid CPU burning at 100%. Thanks @subutux!
* Change logging level from exception to error in connect methods.
* Add check that socket is not None before trying to read or write to
  it.
* Stop thread before disconnecting socket.
* Put disconnect call at end of run method in
  TCPGateway class. This makes sure the while loop is finished before
  disconnecting and avoids errors in socket methods when stopping
  thread.
