### PR TITLE
don't let exceptions in event callback bubble up into library.

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -182,7 +182,10 @@ class Gateway(object):
         Also save sensors if persistence is enabled.
         """
         if self.event_callback is not None:
-            self.event_callback('sensor_update', nid)
+            try:
+                self.event_callback('sensor_update', nid)
+            except Exception as e:
+                LOGGER.exception(e)
 
         if self.persistence:
             self._save_sensors()


### PR DESCRIPTION
library was catching exceptions thrown in callback (ValueError) and logging as "Error decoding message from gateway". 
```python
            except ValueError:
                LOGGER.warning(
                    'Error decoding message from gateway, '
                    'probably received partial data before connection '
                    'was complete.')
```

This was misleading, and took a while to find the cause was a ValueError in the event callback.

This patch suppresses errors in the event callback function, only logging it, instead of falsely catching it further up.
