### PR TITLE
Add test env, local and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "3.4"
@@ -5,6 +6,6 @@ python:
   - "3.5-dev" # 3.5 development branch
   - "nightly" # currently points to 3.6-dev
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: pip install tox-travis
 # command to run tests
-script: nosetests
+script: tox

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -184,8 +184,8 @@ class Gateway(object):
         if self.event_callback is not None:
             try:
                 self.event_callback('sensor_update', nid)
-            except Exception as e:
-                LOGGER.exception(e)
+            except Exception as exception:  # pylint: disable=W0703
+                LOGGER.exception(exception)
 
         if self.persistence:
             self._save_sensors()
@@ -401,7 +401,7 @@ class Sensor:
                             type=msg_type, ack=ack, sub_type=value_type,
                             payload=value)
         return None
-        # TODO: Handle error
+        # TODO: Handle error # pylint: disable=W0511
 
 
 class ChildSensor:

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,9 @@
+[MASTER]
+reports=no
+
+# Reasons disabled:
+# locally-disabled - it spams too much
+# duplicate-code - unavoidable
+disable=
+  locally-disabled,
+  duplicate-code,

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,6 @@
+flake8>=2.5.1
+pylint>=1.5.3
+pytest>=2.8.0
+pytest-cov>=2.2.0
+pytest-timeout>=1.0.0
+pydocstyle>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = D203

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pymysensors."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py34, py35, lint
+skip_missing_interpreters = True
+
+[tox:travis]
+3.5 = py35, lint
+
+[testenv]
+commands =
+     py.test -v --timeout=30 --cov=mysensors --cov-report= {posargs}
+deps =
+     -rrequirements.txt
+     -rrequirements_test.txt
+
+[testenv:lint]
+basepython = python3
+ignore_errors = True
+commands =
+     flake8 mysensors tests
+     pylint mysensors tests
+     pydocstyle mysensors tests


### PR DESCRIPTION
* Add tox.ini to use with tox. Install tox and run tox, to run tests in
  specified environments, currently python3.4 and python3.5. Linting
  tests use pylint, pydocstyle and flake8. Use more python envs on Travis,
  python3.5-dev and nightly.
* Add requirements_test.txt for use in tox.
* Add pylintrc to use with pylint.
* Add setup.cfg and flake8 section for use with flake8.
* Make tests a proper python package directory, to make pydocstyle run.
* Fix lint errors in mysensors.py.
* Update .travis.yml to use the new tox environments and run tox.