### PR TITLE
Handle error for unknown node during presentation

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -46,6 +46,10 @@ class Gateway(object):
             self.alert(msg.node_id)
         else:
             # this is a presentation of a child sensor
+            if not self.is_sensor(msg.node_id):
+                LOGGER.error('Node %s is unknown, will not add child sensor.',
+                             msg.node_id)
+                return
             self.sensors[msg.node_id].add_child_sensor(msg.child_id,
                                                        msg.sub_type)
             self.alert(msg.node_id)

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -29,6 +29,9 @@ class TestGateway(unittest.TestCase):
         self.gateway.logic('1;255;3;0;0;79\n')
         self.assertNotIn(1, self.gateway.sensors)
 
+        self.gateway.logic('1;1;0;0;0;\n')
+        self.assertNotIn(1, self.gateway.sensors)
+
     def test_internal_id_request(self):
         """Test internal node id request."""
         ret = self.gateway.logic('255;255;3;0;3;\n')


### PR DESCRIPTION
* Use dict lookup to see if node exists, before adding child to node.
* If node is None, log error and return.