### PR TITLE
Move except statements upstream

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -109,7 +109,10 @@ class Gateway(object):
         Response is returned to the caller and has to be sent
         data as a mysensors command string.
         """
-        msg = Message(data)
+        try:
+            msg = Message(data)
+        except ValueError:
+            return None
 
         if msg.type == self.const.MessageType.presentation:
             self._handle_presentation(msg)
@@ -327,19 +330,9 @@ class SerialGateway(Gateway, threading.Thread):
             if self.serial is None and not self.connect():
                 time.sleep(self.reconnect_timeout)
                 continue
-            try:
-                response = self.handle_queue()
-            except ValueError:
-                LOGGER.warning(
-                    'Error decoding message from gateway, '
-                    'probably received partial data before connection '
-                    'was complete.')
+            response = self.handle_queue()
             if response is not None:
-                try:
-                    self.send(response.encode())
-                except ValueError:
-                    LOGGER.exception('Invalid response')
-                    continue
+                self.send(response.encode())
             try:
                 line = self.serial.readline()
                 if not line:
@@ -354,15 +347,18 @@ class SerialGateway(Gateway, threading.Thread):
                 continue
             try:
                 string = line.decode('utf-8')
-                self.fill_queue(self.logic, (string,))
             except ValueError:
                 LOGGER.warning(
                     'Error decoding message from gateway, '
                     'probably received bad byte.')
                 continue
+            self.fill_queue(self.logic, (string,))
 
     def send(self, message):
         """Write a Message to the gateway."""
+        if not message or not isinstance(message, str):
+            LOGGER.warning('Missing string! No message sent!')
+            return
         # Lock to make sure only one thread writes at a time to serial port.
         with self.lock:
             self.serial.write(message.encode())
@@ -440,24 +436,33 @@ class Message:
 
     def decode(self, data):
         """Decode a message from command string."""
-        data = data.rstrip().split(';')
-        self.payload = data.pop()
-        (self.node_id,
-         self.child_id,
-         self.type,
-         self.ack,
-         self.sub_type) = [int(f) for f in data]
+        try:
+            list_data = data.rstrip().split(';')
+            self.payload = list_data.pop()
+            (self.node_id,
+             self.child_id,
+             self.type,
+             self.ack,
+             self.sub_type) = [int(f) for f in list_data]
+        except ValueError:
+            LOGGER.warning('Error decoding message from gateway, '
+                           'bad data received: %s', data)
+            raise ValueError
 
     def encode(self):
         """Encode a command string from message."""
-        return ';'.join([str(f) for f in [
-            self.node_id,
-            self.child_id,
-            int(self.type),
-            self.ack,
-            int(self.sub_type),
-            self.payload,
-        ]]) + '\n'
+        try:
+            return ';'.join([str(f) for f in [
+                self.node_id,
+                self.child_id,
+                int(self.type),
+                self.ack,
+                int(self.sub_type),
+                self.payload,
+            ]]) + '\n'
+        except ValueError:
+            LOGGER.exception('Error encoding message to gateway')
+            return None
 
 
 class MySensorsJSONEncoder(json.JSONEncoder):

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -18,6 +18,10 @@ class TestGateway(unittest.TestCase):
         self.gateway.sensors[sensorid] = my.Sensor(sensorid)
         return self.gateway.sensors[sensorid]
 
+    def test_logic_bad_message(self):
+        """Test decode of bad message in logic method."""
+        self.assertEqual(self.gateway.logic('bad;bad;bad;bad;bad;bad\n'), None)
+
     def test_non_presented_sensor(self):
         """Test non presented sensor node."""
         self.gateway.logic('1;0;1;0;23;43\n')
@@ -192,6 +196,13 @@ class TestMessage(unittest.TestCase):
         cmd = msg.encode()
         self.assertEqual(cmd, '255;255;3;0;0;57\n')
 
+    def test_encode_bad_message(self):
+        """Test encode of bad message."""
+        msg = my.Message()
+        msg.sub_type = 'bad'
+        cmd = msg.encode()
+        self.assertEqual(cmd, None)
+
     def test_decode(self):
         """Test decode of message."""
         msg = my.Message('255;255;3;0;0;57\n')
@@ -201,6 +212,11 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(msg.sub_type, Internal.I_BATTERY_LEVEL)
         self.assertEqual(msg.ack, 0)
         self.assertEqual(msg.payload, '57')
+
+    def test_decode_bad_message(self):
+        """Test decode of bad message."""
+        with self.assertRaises(ValueError):
+            my.Message('bad;bad;bad;bad;bad;bad\n')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Add try... except ValueError to decode and encode methods in Message
  class. Remove the corresponding try... except statements in run
  method in SerialGateway class. Also add try... except ValueError in
  logic method to handle raised ValueError in Message.decode method.
* Move statements out of try... except blocks that don't need to be
  there, to not catch things blindly.
* Add guard clause to send method in SerialGateway class.
* Fix PEP issues.
* Add unit tests.