### PR TITLE
Handle heartbeat message

### DIFF
--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -216,6 +216,29 @@ class TestGateway20(TestGateway):
         """Setup gateway."""
         self.gateway = my.Gateway(protocol_version='2.0')
 
+    def test_heartbeat(self):
+        """Test heartbeat message."""
+        sensor = self._add_sensor(1)
+        sensor.children[0] = my.ChildSensor(
+            0, self.gateway.const.Presentation.S_LIGHT_LEVEL)
+        self.gateway.logic('1;0;1;0;23;43\n')
+        ret = self.gateway.handle_queue()
+        self.assertEqual(ret, None)
+        self.gateway.logic('1;255;3;0;22;\n')
+        ret = self.gateway.handle_queue()
+        self.assertEqual(ret, None)
+        self.gateway.set_child_value(1, 0, 23, '57')
+        self.gateway.logic('1;255;3;0;22;\n')
+        ret = self.gateway.handle_queue()
+        self.assertEqual(ret, '1;0;1;0;23;57\n')
+        self.gateway.logic('1;0;2;0;23;\n')
+        self.gateway.logic('1;255;3;0;22;\n')
+        ret = self.gateway.handle_queue()
+        self.assertEqual(ret, '1;0;1;0;23;57\n')
+        self.gateway.logic('1;255;3;0;22;\n')
+        ret = self.gateway.handle_queue()
+        self.assertEqual(ret, None)
+
 
 class TestMessage(TestCase):
     """Test the Message class and it's encode/decode functions."""


### PR DESCRIPTION
* Add method _handle_heartbeat to handle internal message of type
  I_HEARTBEAT_RESPONSE.
* Add an instance attribute new_state to Sensor class. This attribute
  represents the new state of the dictionary stored in Sensor
  attribute children. The new state is what a controller wants to
  achieve. The children dictionary is only
  updated when I_HEARTBEAT_RESPONSE is received and _handle_heartbeat
  is called.
* Add attribute queue of type collections.deque in Sensor class. Use
  the deque to store replies for received messages. Add replies to
  queue when heartbeat is received.
* Fill Gateway.queue in _handle_heartbeat with commands from new_state
  and Sensor.queue. Get tasks from Gateway.queue until it's
  empty in run loop before receiving new messages.
* Update set_child_value method in Sensor class to handle kwarg
  children. This is used in Gateway method set_child_value to update
  values of new_state Sensor attribute.
* Update method _handle_internal to redirect message with
  I_HEARTBEAT_RESPONSE to _handle_heartbeat.
* Update set_child_value in Gateway class, to not fill queue and
  instead update new_state dict if new_state is non empty. It's non
  empty if _handle_heartbeat has been called at least once.
* Clean up send method in SerialGateway class.
* Update run methods in SerialGateway and TCPGateway where send method
  is called.
* Add str and repr magic methods to ChildSensor class.
* Add tests for heartbeat message.
* Update tests to handle updated logic method return type.
* Check protocol version before checking heartbeat internal message.
* Remove unnecessary log message.
* Remove unnecessary return statements.
* Add validation of child values.
* Fix check of protocol version at Gateway init.