### PR TITLE
Add MQTT client Gateway layer

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -1,0 +1,60 @@
+"""Example for using pymysensors with mqtt."""
+import paho.mqtt.client as mqtt  # pylint: disable=E0401
+
+import mysensors.mysensors as mysensors
+
+
+class MQTT(object):
+    """MQTT client example."""
+
+    # pylint: disable=unused-argument
+
+    def __init__(self, broker, port, keepalive):
+        """Setup MQTT client."""
+        self.topics = {}
+        self._mqttc = mqtt.Client()
+        self._mqttc.connect(broker, port, keepalive)
+
+    def publish(self, topic, payload, qos, retain):
+        """Publish an MQTT message."""
+        self._mqttc.publish(topic, payload, qos, retain)
+
+    def subscribe(self, topic, callback, qos):
+        """Subscribe to an MQTT topic."""
+        if topic in self.topics:
+            return
+
+        def _message_callback(mqttc, userdata, msg):
+            """Callback added to callback list for received message."""
+            callback(msg.topic, msg.payload.decode('utf-8'), msg.qos)
+
+        self._mqttc.subscribe(topic, qos)
+        self._mqttc.message_callback_add(topic, _message_callback)
+        self.topics[topic] = callback
+
+    def start(self):
+        """Run the MQTT client."""
+        print('Start MQTT client')
+        self._mqttc.loop_start()
+
+    def stop(self):
+        """Stop the MQTT client."""
+        print('Stop MQTT client')
+        self._mqttc.disconnect()
+        self._mqttc.loop_stop()
+
+
+def event(update_type, nid):
+    """Callback for mysensors updates."""
+    print(update_type + " " + str(nid))
+
+MQTTC = MQTT('localhost', 1883, 60)
+MQTTC.start()
+
+GATEWAY = mysensors.MQTTGateway(
+    MQTTC.publish, MQTTC.subscribe, event_callback=event,
+    protocol_version="2.0", in_prefix='mygateway1-out',
+    out_prefix='mygateway1-in', retain=True)
+
+GATEWAY.debug = True
+GATEWAY.start()

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -653,9 +653,9 @@ class MQTTGateway(Gateway, threading.Thread):
         else:
             # this is a presentation of a child sensor
             topics = [
-                '{}/{}/{}/{}/+/{}'.format(
+                '{}/{}/{}/{}/+/+'.format(
                     self._in_prefix, str(msg.node_id), str(msg.child_id),
-                    msg_type, str(msg.sub_type)) for msg_type in ('1', '2')
+                    msg_type) for msg_type in ('1', '2')
             ]
             self._handle_subscription(topics)
 

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -728,7 +728,7 @@ class Sensor:
             ack = kwargs.get('ack', 0)
             return msg.copy(node_id=self.sensor_id, child_id=child_id,
                             type=msg_type, ack=ack, sub_type=value_type,
-                            payload=value)
+                            payload=value).encode()
         return None
         # TODO: Handle error # pylint: disable=W0511
 

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -600,6 +600,7 @@ class MQTTGateway(Gateway, threading.Thread):
             except ValueError:
                 qos = 0
             try:
+                LOGGER.debug('Subscribing to: %s', topic)
                 self._sub_callback(topic, self.recv, qos)
             except Exception as exception:  # pylint: disable=W0703
                 LOGGER.exception(

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -595,7 +595,10 @@ class MQTTGateway(Gateway, threading.Thread):
             topics = [topics]
         for topic in topics:
             topic_levels = topic.split('/')
-            qos = int(topic_levels[4])
+            try:
+                qos = int(topic_levels[4])
+            except ValueError:
+                qos = 0
             try:
                 self._sub_callback(topic, self.recv, qos)
             except Exception as exception:  # pylint: disable=W0703

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -51,7 +51,7 @@ class Gateway(object):
             self.sensors[msg.node_id].type = msg.sub_type
             self.sensors[msg.node_id].protocol_version = msg.payload
             self.alert(msg.node_id)
-            return msg if sensorid else None
+            return msg if sensorid is not None else None
         else:
             # this is a presentation of a child sensor
             if not self.is_sensor(msg.node_id):
@@ -61,7 +61,7 @@ class Gateway(object):
             child_id = self.sensors[msg.node_id].add_child_sensor(
                 msg.child_id, msg.sub_type)
             self.alert(msg.node_id)
-            return msg if child_id else None
+            return msg if child_id is not None else None
 
     def _handle_set(self, msg):
         """Process a set message."""

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -119,20 +119,21 @@ class Gateway(object):
         Response is returned to the caller and has to be sent
         data as a mysensors command string.
         """
+        ret = None
         try:
             msg = Message(data)
         except ValueError:
-            return None
+            return ret
 
         if msg.type == self.const.MessageType.presentation:
             self._handle_presentation(msg)
         elif msg.type == self.const.MessageType.set:
             self._handle_set(msg)
         elif msg.type == self.const.MessageType.req:
-            return self._handle_req(msg)
+            ret = self._handle_req(msg)
         elif msg.type == self.const.MessageType.internal:
-            return self._handle_internal(msg)
-        return None
+            ret = self._handle_internal(msg)
+        return ret.encode() if ret else None
 
     def _save_pickle(self, filename):
         """Save sensors to pickle file."""
@@ -378,7 +379,7 @@ class SerialGateway(Gateway, threading.Thread):
                 continue
             response = self.handle_queue()
             if response is not None:
-                self.send(response.encode())
+                self.send(response)
             try:
                 line = self.serial.readline()
                 if not line:
@@ -553,7 +554,7 @@ class TCPGateway(Gateway, threading.Thread):
             if available_socks[1] and self.sock is not None:
                 response = self.handle_queue()
                 if response is not None:
-                    self.send(response.encode())
+                    self.send(response)
             if available_socks[0] and self.sock is not None:
                 string = self.recv_timeout()
                 lines = string.split('\n')
@@ -562,6 +563,126 @@ class TCPGateway(Gateway, threading.Thread):
                 for line in lines:
                     self.fill_queue(self.logic, (line,))
         self.disconnect()
+
+
+class MQTTGateway(Gateway, threading.Thread):
+    """MySensors MQTT client gateway."""
+
+    # pylint: disable=too-many-arguments
+
+    def __init__(self, pub_callback, sub_callback, event_callback=None,
+                 persistence=False, persistence_file="mysensors.pickle",
+                 protocol_version="1.4", in_prefix=None, out_prefix=None,
+                 retain=True):
+        """Setup MQTT client gateway."""
+        threading.Thread.__init__(self)
+        Gateway.__init__(self, event_callback, persistence,
+                         persistence_file, protocol_version)
+        # Should accept topic, payload, qos, retain.
+        self._pub_callback = pub_callback
+        # Should accept topic and function callback for receive.
+        self._sub_callback = sub_callback
+        self._in_prefix = in_prefix  # prefix for topics gw -> controller
+        self._out_prefix = out_prefix  # prefix for topics controller -> gw
+        self._retain = retain  # flag to publish with retain
+        self._stop_event = threading.Event()
+        self._init_topics()
+        # topic structure:
+        # prefix/node/child/type/ack/subtype : payload
+
+    def _handle_subscription(self, topics):
+        """Handle subscription of topics."""
+        if not isinstance(topics, list):
+            topics = [topics]
+        for topic in topics:
+            try:
+                self._sub_callback(topic, self.recv)
+            except Exception as exception:  # pylint: disable=W0703
+                LOGGER.exception(
+                    'Subscribe to %s failed: %s', topic, exception)
+
+    def _init_topics(self):
+        """Setup initial subscription of mysensors topics."""
+        init_topics = [
+            '{}/+/255/0/+/+'.format(self._in_prefix),
+            '{}/+/+/3/+/+'.format(self._in_prefix),
+        ]
+        self._handle_subscription(init_topics)
+
+    def _parse_mqtt_to_message(self, topic, payload, qos):
+        """Parse a MQTT topic and payload.
+
+        Return a mysensors command string.
+        """
+        topic_levels = topic.split('/')
+        prefix = topic_levels.pop(0)
+        if prefix not in self._in_prefix:
+            return
+        if qos and qos > 0:
+            ack = '1'
+        else:
+            ack = '0'
+        topic_levels[3] = ack
+        topic_levels.append(str(payload))
+        return ';'.join(topic_levels)
+
+    def _parse_message_to_mqtt(self, data):
+        """Parse a mysensors command string.
+
+        Return a MQTT topic, payload and qos-level as a tuple.
+        """
+        msg = Message(data)
+        payload = str(msg.payload)
+        msg.payload = ''
+        # prefix/node/child/type/ack/subtype : payload
+        return ('{}/{}'.format(self._out_prefix, msg.encode('/'))[:-1],
+                payload, msg.ack)
+
+    def _handle_presentation(self, msg):
+        """Process a MQTT presentation message."""
+        super()._handle_presentation(msg)
+        if msg.child_id == 255:
+            # this is a presentation of the sensor platform
+            self._handle_subscription('{}/{}/+/0/+/+'.format(
+                self._in_prefix, str(msg.node_id)))
+        else:
+            # this is a presentation of a child sensor
+            topics = [
+                '{}/{}/{}/{}/+/{}'.format(
+                    self._in_prefix, str(msg.node_id), str(msg.child_id),
+                    msg_type, str(msg.sub_type)) for msg_type in ('1', '2')
+            ]
+            self._handle_subscription(topics)
+
+    def recv(self, topic, payload, qos):
+        """Receive a MQTT message.
+
+        Call this method when a message is received from the MQTT broker.
+        """
+        data = self._parse_mqtt_to_message(topic, payload, qos)
+        LOGGER.debug('Receiving %s', data)
+        self.fill_queue(self.logic, (data,))
+
+    def send(self, message):
+        """Publish a command string to the gateway via MQTT."""
+        if not message:
+            return
+        topic, payload, qos = self._parse_message_to_mqtt(message)
+        with self.lock:
+            try:
+                LOGGER.debug('Publishing %s', message)
+                self._pub_callback(topic, payload, qos, self._retain)
+            except Exception as exception:  # pylint: disable=W0703
+                LOGGER.exception('Publish to %s failed: %s', topic, exception)
+
+    def run(self):
+        """Background thread that sends messages to the gateway via MQTT."""
+        self.setup_logging()
+        while not self._stop_event.is_set():
+            time.sleep(0.02)  # short sleep to avoid burning 100% cpu
+            response = self.handle_queue()
+            if response is not None:
+                self.send(response)
 
 
 class Sensor:
@@ -634,10 +755,10 @@ class Message:
             setattr(msg, key, val)
         return msg
 
-    def decode(self, data):
+    def decode(self, data, delimiter=';'):
         """Decode a message from command string."""
         try:
-            list_data = data.rstrip().split(';')
+            list_data = data.rstrip().split(delimiter)
             self.payload = list_data.pop()
             (self.node_id,
              self.child_id,
@@ -649,10 +770,10 @@ class Message:
                            'bad data received: %s', data)
             raise ValueError
 
-    def encode(self):
+    def encode(self, delimiter=';'):
         """Encode a command string from message."""
         try:
-            return ';'.join([str(f) for f in [
+            return delimiter.join([str(f) for f in [
                 self.node_id,
                 self.child_id,
                 int(self.type),

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -604,6 +604,7 @@ class MQTTGateway(Gateway, threading.Thread):
 
     def _init_topics(self):
         """Setup initial subscription of mysensors topics."""
+        LOGGER.info('Setting up initial MQTT topic subscription')
         init_topics = [
             '{}/+/255/0/+/+'.format(self._in_prefix),
             '{}/+/+/3/+/+'.format(self._in_prefix),
@@ -675,6 +676,11 @@ class MQTTGateway(Gateway, threading.Thread):
                 self._pub_callback(topic, payload, qos, self._retain)
             except Exception as exception:  # pylint: disable=W0703
                 LOGGER.exception('Publish to %s failed: %s', topic, exception)
+
+    def stop(self):
+        """Stop the background thread."""
+        LOGGER.info('Stopping thread')
+        self._stop_event.set()
 
     def run(self):
         """Background thread that sends messages to the gateway via MQTT."""

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -586,7 +586,6 @@ class MQTTGateway(Gateway, threading.Thread):
         self._out_prefix = out_prefix  # prefix for topics controller -> gw
         self._retain = retain  # flag to publish with retain
         self._stop_event = threading.Event()
-        self._init_topics()
         # topic structure:
         # prefix/node/child/type/ack/subtype : payload
 
@@ -678,6 +677,7 @@ class MQTTGateway(Gateway, threading.Thread):
     def run(self):
         """Background thread that sends messages to the gateway via MQTT."""
         self.setup_logging()
+        self._init_topics()
         while not self._stop_event.is_set():
             time.sleep(0.02)  # short sleep to avoid burning 100% cpu
             response = self.handle_queue()

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -580,7 +580,7 @@ class MQTTGateway(Gateway, threading.Thread):
                          persistence_file, protocol_version)
         # Should accept topic, payload, qos, retain.
         self._pub_callback = pub_callback
-        # Should accept topic and function callback for receive.
+        # Should accept topic, function callback for receive and qos.
         self._sub_callback = sub_callback
         self._in_prefix = in_prefix  # prefix for topics gw -> controller
         self._out_prefix = out_prefix  # prefix for topics controller -> gw
@@ -594,8 +594,10 @@ class MQTTGateway(Gateway, threading.Thread):
         if not isinstance(topics, list):
             topics = [topics]
         for topic in topics:
+            topic_levels = topic.split('/')
+            qos = int(topic_levels[4])
             try:
-                self._sub_callback(topic, self.recv)
+                self._sub_callback(topic, self.recv, qos)
             except Exception as exception:  # pylint: disable=W0703
                 LOGGER.exception(
                     'Subscribe to %s failed: %s', topic, exception)

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -38,7 +38,7 @@ class TestGateway(TestCase):
     def test_internal_id_request(self):
         """Test internal node id request."""
         ret = self.gateway.logic('255;255;3;0;3;\n')
-        self.assertEqual(ret.encode(), '255;255;3;0;4;1\n')
+        self.assertEqual(ret, '255;255;3;0;4;1\n')
         self.assertIn(1, self.gateway.sensors)
 
     def test_presentation_arduino_node(self):
@@ -53,11 +53,11 @@ class TestGateway(TestCase):
         """Test internal config request, metric or imperial."""
         # metric
         ret = self.gateway.logic('1;255;3;0;6;0\n')
-        self.assertEqual(ret.encode(), '1;255;3;0;6;M\n')
+        self.assertEqual(ret, '1;255;3;0;6;M\n')
         # imperial
         self.gateway.metric = False
         ret = self.gateway.logic('1;255;3;0;6;0\n')
-        self.assertEqual(ret.encode(), '1;255;3;0;6;I\n')
+        self.assertEqual(ret, '1;255;3;0;6;I\n')
 
     def test_internal_time(self):
         """Test internal time request."""
@@ -65,7 +65,7 @@ class TestGateway(TestCase):
         with mock.patch('mysensors.mysensors.time') as mock_time:
             mock_time.time.return_value = 123456789
             ret = self.gateway.logic('1;255;3;0;1;\n')
-            self.assertEqual(ret.encode(), '1;255;3;0;1;123456789\n')
+            self.assertEqual(ret, '1;255;3;0;1;123456789\n')
 
     def test_internal_sketch_name(self):
         """Test internal receive of sketch name."""
@@ -127,7 +127,7 @@ class TestGateway(TestCase):
             1, self.gateway.const.Presentation.S_POWER)
         sensor.set_child_value(1, self.gateway.const.SetReq.V_VAR1, 42)
         ret = self.gateway.logic('1;1;2;0;24;\n')
-        self.assertEqual(ret.encode(), '1;1;1;0;24;42\n')
+        self.assertEqual(ret, '1;1;1;0;24;42\n')
 
     def test_req_zerovalue(self):
         """Test req message in case where value exists but is zero."""
@@ -136,7 +136,7 @@ class TestGateway(TestCase):
             1, self.gateway.const.Presentation.S_POWER)
         sensor.set_child_value(1, self.gateway.const.SetReq.V_VAR1, 0)
         ret = self.gateway.logic('1;1;2;0;24;\n')
-        self.assertEqual(ret.encode(), '1;1;1;0;24;0\n')
+        self.assertEqual(ret, '1;1;1;0;24;0\n')
 
     def test_req_novalue(self):
         """Test req message for sensor with no value."""


### PR DESCRIPTION
* Add MQTT Gateway class. This should be implemented by an external
  module on the controller that interfaces with an MQTT broker. Ie both
  broker and broker interface needs to be handled externally.
  * The MQTT Gateway needs two positional arguments at instantiation:
    1. A function to publish messages to topics on the MQTT broker.
      This function should accept four arguments, topic (str), payload
      (str), qos (int) and retain (bool).
    2. A function to subscribe to topics on the MQTT broker. This
      function should accept three arguments, topic (str), a callback
      function for receiving messages (obj) and qos (int).
  * The MQTT Gateway also takes three extra keyword arguments:
    * in_prefix (str) for topics gw -> controller.
    * out_prefix (str) for topics controller -> gw.
    * retain (bool) flag to publish with retain.
* Add messages to queue, to support sending messages from controller.
* Change return value of logic method to return a mysensors command
  string or None.
* Update tests to reflect changes to return value of logic method.