### PR TITLE
Add OTA firmware update feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,8 @@ def event(update_type, nid):
     print(update_type + " " + str(nid))
 
 # To create a serial gateway.
-GATEWAY = mysensors.SerialGateway('/dev/ttyACM0', event, True)
+GATEWAY = mysensors.SerialGateway(
+    '/dev/ttyACM0', event, protocol_version='2.0')
 
 # To create a TCP gateway.
 # GATEWAY = mysensors.TCPGateway('127.0.0.1', event, True)
@@ -15,5 +16,5 @@ GATEWAY = mysensors.SerialGateway('/dev/ttyACM0', event, True)
 GATEWAY.debug = True
 GATEWAY.start()
 # To set sensor 1, child 1, sub-type V_LIGHT (= 2), with value 1.
-GATEWAY.set_child_value(1, 1, 2, 1)
-GATEWAY.stop()
+# GATEWAY.set_child_value(1, 1, 2, 1)
+# GATEWAY.stop()

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -135,3 +135,16 @@ class Internal(IntEnum):
     I_REBOOT = 13
     # Send by gateway to controller when startup is complete
     I_GATEWAY_READY = 14
+
+
+class Stream(IntEnum):
+    """MySensors stream sub-types."""
+
+    # Request new FW, payload contains current FW details
+    ST_FIRMWARE_CONFIG_REQUEST = 0
+    # New FW details to initiate OTA FW update
+    ST_FIRMWARE_CONFIG_RESPONSE = 1
+    ST_FIRMWARE_REQUEST = 2  # Request FW block
+    ST_FIRMWARE_RESPONSE = 3  # Response FW block
+    ST_SOUND = 4  # Sound
+    ST_IMAGE = 5  # Image

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -174,3 +174,16 @@ class Internal(IntEnum):
     I_GET_NONCE = 16
     # Used between sensors for nonce response.
     I_GET_NONCE_RESPONSE = 17
+
+
+class Stream(IntEnum):
+    """MySensors stream sub-types."""
+
+    # Request new FW, payload contains current FW details
+    ST_FIRMWARE_CONFIG_REQUEST = 0
+    # New FW details to initiate OTA FW update
+    ST_FIRMWARE_CONFIG_RESPONSE = 1
+    ST_FIRMWARE_REQUEST = 2  # Request FW block
+    ST_FIRMWARE_RESPONSE = 3  # Response FW block
+    ST_SOUND = 4  # Sound
+    ST_IMAGE = 5  # Image

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -233,3 +233,16 @@ class Internal(IntEnum):
     I_REGISTRATION_REQUEST = 26  # Register request to GW
     I_REGISTRATION_RESPONSE = 27  # Register response from GW
     I_DEBUG = 28  # Debug message
+
+
+class Stream(IntEnum):
+    """MySensors stream sub-types."""
+
+    # Request new FW, payload contains current FW details
+    ST_FIRMWARE_CONFIG_REQUEST = 0
+    # New FW details to initiate OTA FW update
+    ST_FIRMWARE_CONFIG_RESPONSE = 1
+    ST_FIRMWARE_REQUEST = 2  # Request FW block
+    ST_FIRMWARE_RESPONSE = 3  # Response FW block
+    ST_SOUND = 4  # Sound
+    ST_IMAGE = 5  # Image

--- a/mysensors/ota.py
+++ b/mysensors/ota.py
@@ -1,0 +1,184 @@
+"""Handle MySensors OTA FW updates."""
+import binascii
+import logging
+import os
+import struct
+
+import crcmod.predefined
+from intelhex import IntelHex, IntelHexError
+
+FIRMWARE_BLOCK_SIZE = 16
+_LOGGER = logging.getLogger(__name__)
+
+
+def fw_hex_to_int(hex_str, words):
+    """Unpack hex string into integers.
+
+    Use little-endian and unsigned int format. Specify number of words to
+    unpack with argument words.
+    """
+    return struct.unpack('<{}H'.format(words), binascii.unhexlify(hex_str))
+
+
+def fw_int_to_hex(*args):
+    """Pack integers into hex string.
+
+    Use little-endian and unsigned int format.
+    """
+    return binascii.hexlify(
+        struct.pack('<{}H'.format(len(args)), *args)).decode('utf-8')
+
+
+def compute_crc(data):
+    """Compute CRC16 of data and return an int."""
+    crc16 = crcmod.predefined.Crc('modbus')
+    crc16.update(data)
+    return int(crc16.hexdigest(), 16)
+
+
+def check_fw(path):
+    """Check that firmware is valid and return dict with binary data."""
+    try:
+        intel_hex = IntelHex()
+        with open(path, 'r') as file_handle:
+            intel_hex.fromfile(file_handle, format='hex')
+        bin_string = intel_hex.tobinstr()
+    except (IntelHexError, TypeError, ValueError) as exception:
+        _LOGGER.error(exception)
+        return
+    pads = len(bin_string) % 128  # 128 bytes per page for atmega328
+    for _ in range(128 - pads):  # pad up to even 128 bytes
+        bin_string += b'\xff'
+    fware = {
+        'path': path,
+        'blocks': int(len(bin_string) / FIRMWARE_BLOCK_SIZE),
+        'crc': compute_crc(bin_string),
+        'data': bin_string,
+    }
+    return fware
+
+
+class OTAFirmware(object):
+    """Organize OTAFirmware updates."""
+
+    def __init__(self, sensors, const):
+        """Setup OTA firmware instance."""
+        self._sensors = sensors
+        self._const = const
+        self.firmware = {}
+        self.requested = {}
+        self.started = {}
+        self.unstarted = {}
+
+    def _get_fw(self, msg, updates, req_fw_type=None, req_fw_ver=None):
+        """Get firmware type, version and a dict holding binary data."""
+        fw_type = None
+        fw_ver = None
+        if not isinstance(updates, tuple):
+            updates = (updates, )
+        for store in updates:
+            fw_id = store.pop(msg.node_id, None)
+            if fw_id is not None:
+                fw_type, fw_ver = fw_id
+                updates[-1][msg.node_id] = fw_id
+                break
+        if fw_type is None or fw_ver is None:
+            _LOGGER.debug(
+                'Node %s is not set for firmware update', msg.node_id)
+            return None, None, None
+        if req_fw_type is not None and req_fw_ver is not None:
+            fw_type, fw_ver = req_fw_type, req_fw_ver
+        fware = self.firmware.get((fw_type, fw_ver))
+        if fware is None:
+            _LOGGER.debug(
+                'No firmware of type %s and version %s found',
+                fw_type, fw_ver)
+            return None, None, None
+        return fw_type, fw_ver, fware
+
+    def respond_fw(self, msg):
+        """Respond to a firmware request."""
+        req_fw_type, req_fw_ver, req_blk = fw_hex_to_int(msg.payload, 3)
+        _LOGGER.debug(
+            'Received firmware request with firmware type %s, '
+            'firmware version %s, block index %s',
+            req_fw_type, req_fw_ver, req_blk)
+        fw_type, fw_ver, fware = self._get_fw(
+            msg, (self.unstarted, self.started), req_fw_type, req_fw_ver)
+        if fware is None:
+            return
+        blk_data = fware['data'][
+            req_blk * FIRMWARE_BLOCK_SIZE:
+            req_blk * FIRMWARE_BLOCK_SIZE + FIRMWARE_BLOCK_SIZE]
+        msg = msg.copy(sub_type=self._const.Stream.ST_FIRMWARE_RESPONSE)
+        msg.payload = fw_int_to_hex(fw_type, fw_ver, req_blk)
+        # format blk_data into payload format
+        msg.payload = msg.payload + binascii.hexlify(blk_data).decode('utf-8')
+        return msg
+
+    def respond_fw_config(self, msg):
+        """Respond to a firmware config request."""
+        (req_fw_type,
+         req_fw_ver,
+         req_blocks,
+         req_crc,
+         bloader_ver) = fw_hex_to_int(msg.payload, 5)
+        _LOGGER.debug(
+            'Received firmware config request with firmware type %s, '
+            'firmware version %s, %s blocks, CRC %s, bootloader %s',
+            req_fw_type, req_fw_ver, req_blocks, req_crc, bloader_ver)
+        fw_type, fw_ver, fware = self._get_fw(
+            msg, (self.requested, self.unstarted))
+        if fware is None:
+            return
+        if fw_type != req_fw_type:
+            _LOGGER.warning(
+                'Firmware type %s of update is not identical to existing '
+                'firmware type %s for node %s',
+                fw_type, req_fw_type, msg.node_id)
+        _LOGGER.info(
+            'Updating node %s to firmware type %s version %s from type %s '
+            'version %s', msg.node_id, fw_type, fw_ver, req_fw_type,
+            req_fw_ver)
+        msg = msg.copy(sub_type=self._const.Stream.ST_FIRMWARE_CONFIG_RESPONSE)
+        msg.payload = fw_int_to_hex(
+            fw_type, fw_ver, fware['blocks'], fware['crc'])
+        return msg
+
+    def make_update(self, nids, fw_type, fw_ver, fw_path=None):
+        """Start firmware update process for one or more node_id."""
+        try:
+            fw_type, fw_ver = int(fw_type), int(fw_ver)
+        except ValueError:
+            _LOGGER.error(
+                'Firmware type %s or version %s not valid, '
+                'please enter integers', fw_type, fw_ver)
+            return
+        if fw_path is not None:
+            fname = os.path.realpath(fw_path)
+            exists = os.path.isfile(fname)
+            if not exists or not os.access(fname, os.R_OK):
+                _LOGGER.error(
+                    'Firmware path %s does not exist or is not readable',
+                    fw_path)
+                return
+            fware = check_fw(fw_path)
+            if fware is None:
+                _LOGGER.error(
+                    'Firmware not valid, check the hex file at %s', fw_path)
+                return
+            self.firmware[fw_type, fw_ver] = fware
+        if (fw_type, fw_ver) not in self.firmware:
+            _LOGGER.error(
+                'No firmware of type %s and version %s found, '
+                'please enter path to firmware in call', fw_type, fw_ver)
+            return
+        if not isinstance(nids, list):
+            nids = [nids]
+        for node_id in nids:
+            if node_id not in self._sensors:
+                continue
+            for store in self.unstarted, self.started:
+                store.pop(node_id, None)
+            self.requested[node_id] = fw_type, fw_ver
+            self._sensors[node_id].reboot = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pyserial>=3.1.1
+IntelHex>=2.1
+crcmod>=1.7

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(name='pymysensors',
       url='https://github.com/theolind/pymysensors',
       author='Theodor Lindquist',
       license='MIT',
-      install_requires=['pyserial>=3.1.1'],
+      install_requires=['pyserial>=3.1.1', 'crcmod>=1.7', 'IntelHex>=2.1'],
       packages=['mysensors'],
       zip_safe=True)

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -1,0 +1,200 @@
+"""Test mysensors OTA FW with unittest."""
+import binascii
+import struct
+import tempfile
+from unittest import TestCase, main
+
+import mysensors.mysensors as my
+from mysensors.ota import compute_crc, FIRMWARE_BLOCK_SIZE
+
+FW_TYPE = 1
+FW_VER = 1
+HEX_FILE_STR = ':100000000C94AC030C9491240C94B8240C94D40359\n:00000001FF'
+PADDED_HEX_STR = (
+    '0c94ac030c9491240c94b8240c94d403ffffffffffffffffffffffffffffffff'
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+BLOCKS = int(len(PADDED_HEX_STR) / (2 * FIRMWARE_BLOCK_SIZE))
+BAD_HEX_FILE = 'badcontent'
+
+
+class TestOTA(TestCase):
+    """Test the OTA FW logic."""
+
+    def setUp(self):
+        """Setup gateway."""
+        self.gateway = my.Gateway()
+
+    def _add_sensor(self, sensorid):
+        """Add sensor node. Return sensor node instance."""
+        self.gateway.sensors[sensorid] = my.Sensor(sensorid)
+        return self.gateway.sensors[sensorid]
+
+    def _setup_firmware(self, nids, hex_file_str):
+        """Add node(s) and call update_fw method."""
+        if not isinstance(nids, list):
+            nids = [nids]
+        sensors = [self._add_sensor(node_id) for node_id in nids]
+        with tempfile.NamedTemporaryFile() as file_handle:
+            file_handle.write(
+                hex_file_str.encode('utf-8'))
+            file_handle.flush()
+            self.gateway.update_fw(
+                [sensor.sensor_id for sensor in sensors], FW_TYPE, FW_VER,
+                file_handle.name)
+
+    def test_bad_fw_path(self):
+        """Test firmware update with bad path to firmware."""
+        sensor = self._add_sensor(1)
+        self.gateway.update_fw(
+            sensor.sensor_id, FW_TYPE, FW_VER, '/bad/path')
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertEqual(ret, None)
+
+    def test_bad_fw(self):
+        """Test firmware update with bad firmware."""
+        self._setup_firmware(1, BAD_HEX_FILE)
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertEqual(ret, None)
+
+    def test_no_fw(self):
+        """Test firmware update with no firmware loaded."""
+        sensor = self._add_sensor(1)
+        self.gateway.update_fw(
+            sensor.sensor_id, FW_TYPE, FW_VER)
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertEqual(ret, None)
+
+    def test_bad_fw_type_or_version(self):
+        """Test firmware update with bad firmware type or version."""
+        sensor = self._add_sensor(1)
+        self.gateway.update_fw(
+            sensor.sensor_id, 'a', 'b')
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertEqual(ret, None)
+
+    def test_update_for_no_node(self):
+        """Test firmware update for a not existing node."""
+        with tempfile.NamedTemporaryFile() as file_handle:
+            file_handle.write(
+                HEX_FILE_STR.encode('utf-8'))
+            file_handle.flush()
+            self.gateway.update_fw(
+                1, FW_TYPE, FW_VER, file_handle.name)
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertEqual(ret, None)
+
+    def test_respond_fw_config(self):
+        """Test respond to firmware config request."""
+        self._setup_firmware(1, HEX_FILE_STR)
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        crc = compute_crc(binascii.unhexlify(PADDED_HEX_STR.encode('utf-8')))
+        payload = binascii.hexlify(struct.pack(
+            '<4H', FW_TYPE, FW_VER, BLOCKS, crc)).decode('utf-8')
+        self.assertEqual(ret, '1;255;4;0;1;{}\n'.format(payload))
+
+    def test_respond_fw(self):
+        """Test respond to firmware request."""
+        self._setup_firmware(1, HEX_FILE_STR)
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        # Test that firmware config request generates a response.
+        # A detailed test of the response is done in another test.
+        self.assertIsNotNone(ret)
+        for block in reversed(range(BLOCKS)):
+            payload = binascii.hexlify(
+                struct.pack('<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+            ret = self.gateway.logic('1;255;4;0;2;{}\n'.format(payload))
+            payload = binascii.hexlify(struct.pack(
+                '<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+            blk_data = binascii.unhexlify(PADDED_HEX_STR.encode('utf-8'))[
+                block * FIRMWARE_BLOCK_SIZE:
+                block * FIRMWARE_BLOCK_SIZE + FIRMWARE_BLOCK_SIZE]
+            payload += binascii.hexlify(blk_data).decode('utf-8')
+            self.assertEqual(ret, '1;255;4;0;3;{}\n'.format(payload))
+        # Test that firmware config request does not generate a new response.
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertEqual(ret, None)
+
+    def test_restart_fw_update(self):
+        """Test response after a new call to update firmware of node."""
+        self._setup_firmware(1, HEX_FILE_STR)
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        # Test that firmware config request generates a response.
+        # A detailed test of the response is done in another test.
+        self.assertIsNotNone(ret)
+        block = BLOCKS - 1
+        payload = binascii.hexlify(
+            struct.pack('<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+        ret = self.gateway.logic('1;255;4;0;2;{}\n'.format(payload))
+        payload = binascii.hexlify(struct.pack(
+            '<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+        blk_data = binascii.unhexlify(PADDED_HEX_STR.encode('utf-8'))[
+            block * FIRMWARE_BLOCK_SIZE:
+            block * FIRMWARE_BLOCK_SIZE + FIRMWARE_BLOCK_SIZE]
+        payload += binascii.hexlify(blk_data).decode('utf-8')
+        self.assertEqual(ret, '1;255;4;0;3;{}\n'.format(payload))
+        with tempfile.NamedTemporaryFile() as file_handle:
+            file_handle.write(
+                HEX_FILE_STR.encode('utf-8'))
+            file_handle.flush()
+            self.gateway.update_fw(
+                1, FW_TYPE, FW_VER, file_handle.name)
+        payload = binascii.hexlify(
+            struct.pack('<3H', FW_TYPE, FW_VER, block - 1)).decode('utf-8')
+        ret = self.gateway.logic('1;255;4;0;2;{}\n'.format(payload))
+        # Test that firmware request does not generate a response.
+        self.assertEqual(ret, None)
+        # Test that firmware config request generates a new response.
+        ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
+        self.assertIsNotNone(ret)
+        # Test that firmware request generates all the correct responses.
+        for block in reversed(range(BLOCKS)):
+            payload = binascii.hexlify(
+                struct.pack('<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+            ret = self.gateway.logic('1;255;4;0;2;{}\n'.format(payload))
+            payload = binascii.hexlify(struct.pack(
+                '<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+            blk_data = binascii.unhexlify(PADDED_HEX_STR.encode('utf-8'))[
+                block * FIRMWARE_BLOCK_SIZE:
+                block * FIRMWARE_BLOCK_SIZE + FIRMWARE_BLOCK_SIZE]
+            payload += binascii.hexlify(blk_data).decode('utf-8')
+            self.assertEqual(ret, '1;255;4;0;3;{}\n'.format(payload))
+
+    def test_respond_fw_two_nodes(self):
+        """Test respond to firmware request for two different nodes."""
+        nodes = [1, 2]
+        self._setup_firmware(nodes, HEX_FILE_STR)
+        for node_id in nodes:
+            ret = self.gateway.logic(
+                '{};255;4;0;0;01000200B00626E80300\n'.format(node_id))
+            # Test that firmware config request generates a response.
+            # A detailed test of the response is done in another test.
+            self.assertIsNotNone(ret)
+        for block in reversed(range(BLOCKS)):
+            for node_id in nodes:
+                payload = binascii.hexlify(
+                    struct.pack('<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+                ret = self.gateway.logic(
+                    '{};255;4;0;2;{}\n'.format(node_id, payload))
+                payload = binascii.hexlify(struct.pack(
+                    '<3H', FW_TYPE, FW_VER, block)).decode('utf-8')
+                blk_data = binascii.unhexlify(PADDED_HEX_STR.encode('utf-8'))[
+                    block * FIRMWARE_BLOCK_SIZE:
+                    block * FIRMWARE_BLOCK_SIZE + FIRMWARE_BLOCK_SIZE]
+                payload += binascii.hexlify(blk_data).decode('utf-8')
+                self.assertEqual(
+                    ret, '{};255;4;0;3;{}\n'.format(node_id, payload))
+
+    def test_different_firmware_type(self):
+        """Test respond to fw config request for a different firmware type."""
+        self._setup_firmware(1, HEX_FILE_STR)
+        ret = self.gateway.logic('1;255;4;0;0;02000200B00626E80300\n')
+        crc = compute_crc(binascii.unhexlify(PADDED_HEX_STR.encode('utf-8')))
+        payload = binascii.hexlify(struct.pack(
+            '<4H', FW_TYPE, FW_VER, BLOCKS, crc)).decode('utf-8')
+        self.assertEqual(ret, '1;255;4;0;1;{}\n'.format(payload))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Call Gateway method `update_fw` to set one or more nodes for OTA
firmware update. The method takes three positional arguments and one
keyword arguement. `nids` should be the node id of the node to update.
This can also be a list of many node ids. `fw_type` and `fw_ver` should
be integers representing the firmware type and version. `fw_path` can
take an optional path to a hex file with the new firmware.

After the `update_fw` method has been called a node will be requested
to restart when Gateway receives the next set message. The node will
then send a firmware config request. This will be handled by
`_handle_stream` method and the message passed to `respond_fw_config`
in ota module. If a node receives a proper firmware config response it
will send a firmware request. This will also be handled by
`_handle_stream` and passed to `respond_fw` method in ota module.

* Add ota module with logic for OTA FW updates.
* Add stream subtypes for version 1.4, 1.5 and 2.0 of const module.
* Add new requirements for hex firmware check and crc calculation.
* Add tests for OTA FW.