### PR TITLE
Fix log spam by disconnecting at serial exception

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -461,6 +461,7 @@ class SerialGateway(Gateway, threading.Thread):
                     continue
             except serial.SerialException:
                 _LOGGER.exception('Serial exception')
+                self.disconnect()
                 continue
             except TypeError:
                 # pyserial has a bug that causes a TypeError to be thrown when


### PR DESCRIPTION
Should fix the console/log spamming errors when serial connection throws exception, reported here:
https://github.com/home-assistant/home-assistant/issues/3544