### PR TITLE
Add discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ To update a node child sensor value and send it to the node, use the set_child_v
 GATEWAY.set_child_value(1, 1, 2, 1)
 ```
 
-PyMysensors also supports four other settings. Debug mode, which prints debug information, persistence mode,
+PyMysensors also supports three other settings. Persistence mode,
 which saves the sensor network between runs, persistence file path, which sets the type and path of the persistence file and protocol version which sets the MySensors serial API version.
 
-Debug mode is enabled by setting SerialGateway.debug = True. With persistence mode on, you can restart the gateway without
+With persistence mode on, you can restart the gateway without
 having to restart each individual node in your sensor network. To enable persistance mode, the third argument
 in the constructor should be True. A path to the config file
 can be specified as a fourth argument. The file type (.pickle or .json) will set which persistence protocol to use, pickle or json. JSON files can be read using a normal text editor.
@@ -88,7 +88,6 @@ GATEWAY = mysensors.SerialGateway(
   '/dev/ttyACM0', event_callback=event, persistence=True,
   persistence_file='somefolder/mysensors.pickle', protocol_version='1.4', baud=115200,
   timeout=1.0, reconnect_timeout=10.0)
-GATEWAY.debug = True
 GATEWAY.start()
 ```
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ GATEWAY = mysensors.SerialGateway(
 # To create a TCP gateway.
 # GATEWAY = mysensors.TCPGateway('127.0.0.1', event, True)
 
-GATEWAY.debug = True
 GATEWAY.start()
 # To set sensor 1, child 1, sub-type V_LIGHT (= 2), with value 1.
 # GATEWAY.set_child_value(1, 1, 2, 1)

--- a/mqtt.py
+++ b/mqtt.py
@@ -56,5 +56,4 @@ GATEWAY = mysensors.MQTTGateway(
     protocol_version="2.0", in_prefix='mygateway1-out',
     out_prefix='mygateway1-in', retain=True)
 
-GATEWAY.debug = True
 GATEWAY.start()

--- a/mqtt.py
+++ b/mqtt.py
@@ -1,5 +1,5 @@
 """Example for using pymysensors with mqtt."""
-import paho.mqtt.client as mqtt  # pylint: disable=E0401
+import paho.mqtt.client as mqtt  # pylint: disable=import-error
 
 import mysensors.mysensors as mysensors
 

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -148,3 +148,17 @@ class Stream(IntEnum):
     ST_FIRMWARE_RESPONSE = 3  # Response FW block
     ST_SOUND = 4  # Sound
     ST_IMAGE = 5  # Image
+
+
+HANDLE_INTERNAL = {
+    Internal.I_BATTERY_LEVEL: {
+        'is_sensor': True, 'setattr': 'battery_level', 'fun': 'alert'},
+    Internal.I_SKETCH_NAME: {
+        'is_sensor': True, 'setattr': 'sketch_name', 'fun': 'alert'},
+    Internal.I_SKETCH_VERSION: {
+        'is_sensor': True, 'setattr': 'sketch_version', 'fun': 'alert'},
+    Internal.I_LOG_MESSAGE: {
+        'log': 'debug'},
+    Internal.I_GATEWAY_READY: {
+        'log': 'info'},
+}

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -1,5 +1,7 @@
 """MySensors constants for version 1.5 of MySensors."""
 from enum import IntEnum
+# pylint: disable=unused-import
+from mysensors.const_14 import HANDLE_INTERNAL  # noqa: F401
 
 
 class MessageType(IntEnum):

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -1,6 +1,8 @@
 """MySensors constants for version 1.5 of MySensors."""
 from enum import IntEnum
 
+from mysensors.const_15 import HANDLE_INTERNAL
+
 
 class MessageType(IntEnum):
     """MySensors message types."""
@@ -246,3 +248,15 @@ class Stream(IntEnum):
     ST_FIRMWARE_RESPONSE = 3  # Response FW block
     ST_SOUND = 4  # Sound
     ST_IMAGE = 5  # Image
+
+
+HANDLE_INTERNAL.update({
+    Internal.I_GATEWAY_READY: {
+        'log': 'info', 'msg': {
+            'node_id': 255, 'ack': 0, 'sub_type': Internal.I_DISCOVER,
+            'payload': ''}},
+    Internal.I_HEARTBEAT_RESPONSE: {
+        'fun': '_handle_heartbeat'},
+    Internal.I_DISCOVER_RESPONSE: {
+        'is_sensor': True},
+})

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -105,7 +105,6 @@ class TestGateway(TestCase):
 
     def test_internal_log_message(self):
         """Test internal receive of log message."""
-        self.gateway.debug = True
         payload = 'read: 1-1-0 s=0,c=1,t=1,pt=7,l=5,sg=0:22.0\n'
         data = '0;255;3;0;9;{}'.format(payload)
         with self.assertLogs(level='DEBUG') as test_handle:

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -115,6 +115,18 @@ class TestGateway(TestCase):
             ['DEBUG:mysensors.mysensors:n:0 c:255 t:3 s:9 p:{}'.format(
                 payload[:-1])])
 
+    def test_internal_gateway_ready(self):
+        """Test internal receive gateway ready and send discover request."""
+        payload = 'Gateway startup complete.\n'
+        data = '0;255;3;0;14;{}'.format(payload)
+        with self.assertLogs(level='INFO') as test_handle:
+            ret = self.gateway.logic(data)
+        self.assertEqual(
+            test_handle.output,
+            ['INFO:mysensors.mysensors:n:0 c:255 t:3 s:14 p:{}'.format(
+                payload[:-1])])
+        self.assertEqual(ret, None)
+
     def test_present_light_level_sensor(self):
         """Test presentation of a light level sensor."""
         sensor = self._add_sensor(1)
@@ -348,6 +360,7 @@ class TestGateway(TestCase):
         sensor = self._add_sensor(1)
         sensor.children[0] = my.ChildSensor(
             0, self.gateway.const.Presentation.S_LIGHT_LEVEL)
+        sensor.battery_level = 58
         del self.gateway.sensors[1].__dict__['new_state']
         self.assertNotIn('new_state', self.gateway.sensors[1].__dict__)
         del self.gateway.sensors[1].__dict__['queue']
@@ -365,6 +378,7 @@ class TestGateway(TestCase):
             del self.gateway.sensors[1]
             self.assertNotIn(1, self.gateway.sensors)
             self.gateway._safe_load_sensors()
+            self.assertEqual(self.gateway.sensors[1].battery_level, 58)
             self.assertEqual(self.gateway.sensors[1].new_state, {})
             self.assertEqual(self.gateway.sensors[1].queue, deque())
             self.assertEqual(self.gateway.sensors[1].reboot, False)
@@ -607,6 +621,33 @@ class TestGateway20(TestGateway):
             sensor.new_state[0].values[
                 self.gateway.const.SetReq.V_LIGHT_LEVEL])
 
+    def test_internal_gateway_ready(self):
+        """Test internal receive gateway ready and send discover request."""
+        payload = 'Gateway startup complete.\n'
+        data = '0;255;3;0;14;{}'.format(payload)
+        with self.assertLogs(level='INFO') as test_handle:
+            ret = self.gateway.logic(data)
+        self.assertEqual(
+            test_handle.output,
+            ['INFO:mysensors.mysensors:n:0 c:255 t:3 s:14 p:{}'.format(
+                payload[:-1])])
+        self.assertEqual(ret, '255;255;3;0;20;\n')
+
+    def test_discover_response_unknown(self):
+        """Test internal receive discover response."""
+        # Test sensor 1 unknown.
+        self.gateway.logic('1;255;3;0;21;0')
+        ret = self.gateway.handle_queue()
+        self.assertEqual(ret, '1;255;3;0;19;\n')
+
+    @mock.patch('mysensors.mysensors.Gateway.is_sensor')
+    def test_discover_response_known(self, mock_is_sensor):
+        """Test internal receive discover response."""
+        # Test sensor 1 known.
+        self._add_sensor(1)
+        self.gateway.logic('1;255;3;0;21;0')
+        assert mock_is_sensor.called
+
 
 class TestMessage(TestCase):
     """Test the Message class and it's encode/decode functions."""
@@ -655,6 +696,16 @@ class MySensorsJSONEncoderTestUpgrade(my.MySensorsJSONEncoder):
 
     def default(self, obj):  # pylint: disable=E0202
         """Serialize obj into JSON."""
+        if isinstance(obj, my.Sensor):
+            return {
+                'sensor_id': obj.sensor_id,
+                'children': obj.children,
+                'type': obj.type,
+                'sketch_name': obj.sketch_name,
+                'sketch_version': obj.sketch_version,
+                'battery_level': obj.battery_level,
+                'protocol_version': obj.protocol_version,
+            }
         if isinstance(obj, my.ChildSensor):
             return {
                 'id': obj.id,


### PR DESCRIPTION
* REMOVED FEATURE: Remove debug attribute on Gateway. Let log level
  setting control logging.
* Add check of internal message I_GATEWAT_READY. When this is received,
  broadcast I_DISCOVER internal message.
* Add check of internal message I_DISCOVER_RESPONSE. Check if sensor
  exists, which will in turn send presentation request if sensor is
  missing.
* Clean up pylint disable codes.
* Refactor _handle_internal to avoid too many branches.
* Add dictionary to lookup actions to take in _handle_internal method.
* Add property and setter for battery_level to set value as integer.
* Update JSON persistence to cater for changed attribute name for
  battery level.
* Add and update tests.