### PR TITLE
Add more envs to tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 sudo: false
 language: python
+cache: pip
 python:
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
+  - "3.5-dev"
+  - "3.6"
+  - "3.6-dev"
   # nightly now points to 3.7-dev,
   # which is not supported by latest released tox version
-  - "3.6-dev"
 # command to install dependencies
-install: pip install tox-travis
+install: pip install -U tox-travis
 # command to run tests
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py34, py35, lint
+envlist = py34, py35, py36, lint
 skip_missing_interpreters = True
 
-[tox:travis]
-3.5 = py35, lint
+[travis]
+python =
+  3.5: py35, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
* Add python 3.6 env to tox and travis.
* Enable travis pip cache.