### PR TITLE
Don't change sensors dict when loading persistence file

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -202,7 +202,7 @@ class Gateway(object):
     def _load_pickle(self, filename):
         """Load sensors from pickle file."""
         with open(filename, 'rb') as file_handle:
-            self.sensors = pickle.load(file_handle)
+            self.sensors.update(pickle.load(file_handle))
 
     def _save_json(self, filename):
         """Save sensors to json file."""
@@ -214,7 +214,8 @@ class Gateway(object):
     def _load_json(self, filename):
         """Load sensors from json file."""
         with open(filename, 'r') as file_handle:
-            self.sensors = json.load(file_handle, cls=MySensorsJSONDecoder)
+            self.sensors.update(
+                    json.load(file_handle, cls=MySensorsJSONDecoder))
 
     def _save_sensors(self):
         """Save sensors to file."""


### PR DESCRIPTION
The sensors dict is shared between the gateway and its OTAFirmware
member.

Previous code just loaded a new sensors dict from the persistence file,
thus the gateway and its OTAFirmware members view of the sensors got out
of sync, resulting in that you couldn't ota when loading a persistence
filee.

Signed-off-by: Anton Lundin <glance@acc.umu.se>