### PR TITLE
Add validation of message and child values

### DIFF
--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -1,6 +1,8 @@
 """MySensors constants for version 1.4 of MySensors."""
 from enum import IntEnum
 
+import voluptuous as vol
+
 
 class MessageType(IntEnum):
     """MySensors message types."""
@@ -149,6 +151,175 @@ class Stream(IntEnum):
     ST_SOUND = 4  # Sound
     ST_IMAGE = 5  # Image
 
+
+VALID_MESSAGE_TYPES = {
+    MessageType.presentation: list(Presentation),
+    MessageType.set: list(SetReq),
+    MessageType.req: list(SetReq),
+    MessageType.internal: list(Internal),
+    MessageType.stream: list(Stream),
+}
+
+VALID_PRESENTATION = {
+    member: str for member in list(Presentation)
+}
+
+VALID_TYPES = {
+    Presentation.S_DOOR: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_MOTION: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_SMOKE: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_LIGHT: [SetReq.V_LIGHT, SetReq.V_WATT],
+    Presentation.S_DIMMER: [SetReq.V_LIGHT, SetReq.V_DIMMER, SetReq.V_WATT],
+    Presentation.S_COVER: [
+        SetReq.V_UP, SetReq.V_DOWN, SetReq.V_STOP, SetReq.V_DIMMER],
+    Presentation.S_TEMP: [SetReq.V_TEMP],
+    Presentation.S_HUM: [SetReq.V_HUM],
+    Presentation.S_BARO: [
+        SetReq.V_PRESSURE, SetReq.V_FORECAST],
+    Presentation.S_WIND: [
+        SetReq.V_WIND, SetReq.V_GUST, SetReq.V_DIRECTION],
+    Presentation.S_RAIN: [
+        SetReq.V_RAIN, SetReq.V_RAINRATE],
+    Presentation.S_UV: [SetReq.V_UV],
+    Presentation.S_WEIGHT: [
+        SetReq.V_WEIGHT, SetReq.V_IMPEDANCE],
+    Presentation.S_POWER: [SetReq.V_WATT, SetReq.V_KWH],
+    Presentation.S_HEATER: [SetReq.V_TEMP],
+    Presentation.S_DISTANCE: [SetReq.V_DISTANCE],
+    Presentation.S_LIGHT_LEVEL: [SetReq.V_LIGHT_LEVEL],
+    Presentation.S_ARDUINO_NODE: [],
+    Presentation.S_ARDUINO_RELAY: [],
+    Presentation.S_LOCK: [SetReq.V_LOCK_STATUS],
+    Presentation.S_IR: [SetReq.V_IR_SEND, SetReq.V_IR_RECEIVE],
+    Presentation.S_WATER: [SetReq.V_FLOW, SetReq.V_VOLUME],
+    Presentation.S_AIR_QUALITY: [SetReq.V_DUST_LEVEL],
+    Presentation.S_CUSTOM: [
+        SetReq.V_VAR1, SetReq.V_VAR2, SetReq.V_VAR3, SetReq.V_VAR4,
+        SetReq.V_VAR5],
+    Presentation.S_DUST: [SetReq.V_DUST_LEVEL],
+    Presentation.S_SCENE_CONTROLLER: [SetReq.V_SCENE_ON, SetReq.V_SCENE_OFF],
+}
+
+LOGICAL_ZERO = '0'
+LOGICAL_ONE = '1'
+OFF = 'Off'
+HEAT_ON = 'HeatOn'
+COOL_ON = 'CoolOn'
+AUTO_CHANGE_OVER = 'AutoChangeOver'
+STABLE = 'stable'
+SUNNY = 'sunny'
+CLOUDY = 'cloudy'
+UNSTABLE = 'unstable'
+THUNDERSTORM = 'thunderstorm'
+UNKNOWN = 'unknown'
+FORECASTS = (STABLE, SUNNY, CLOUDY, UNSTABLE, THUNDERSTORM, UNKNOWN)
+
+VALID_SETREQ = {
+    SetReq.V_TEMP: str,
+    SetReq.V_HUM: str,
+    SetReq.V_LIGHT: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_DIMMER: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        msg='value must be between {} and {}'.format(0, 100)),
+    SetReq.V_PRESSURE: str,
+    SetReq.V_FORECAST: vol.Any(str, vol.In(
+        FORECASTS,
+        msg='forecast must be one of: {}, {}, {}, {}, {}, {}'.format(
+            *FORECASTS))),
+    SetReq.V_RAIN: str,
+    SetReq.V_RAINRATE: str,
+    SetReq.V_WIND: str,
+    SetReq.V_GUST: str,
+    SetReq.V_DIRECTION: str,
+    SetReq.V_UV: str,
+    SetReq.V_WEIGHT: str,
+    SetReq.V_DISTANCE: str,
+    SetReq.V_IMPEDANCE: str,
+    SetReq.V_ARMED: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_TRIPPED: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_WATT: str,
+    SetReq.V_KWH: str,
+    SetReq.V_SCENE_ON: str,
+    SetReq.V_SCENE_OFF: str,
+    SetReq.V_HEATER: vol.In(
+        [OFF, HEAT_ON, COOL_ON, AUTO_CHANGE_OVER],
+        msg='value must be one of: {}, {}, {} or {}'.format(
+            OFF, HEAT_ON, COOL_ON, AUTO_CHANGE_OVER)),
+    SetReq.V_HEATER_SW: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_LIGHT_LEVEL: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        msg='value must be between {} and {}'.format(0, 100)),
+    SetReq.V_VAR1: str,
+    SetReq.V_VAR2: str,
+    SetReq.V_VAR3: str,
+    SetReq.V_VAR4: str,
+    SetReq.V_VAR5: str,
+    SetReq.V_UP: str,
+    SetReq.V_DOWN: str,
+    SetReq.V_STOP: str,
+    SetReq.V_IR_SEND: str,
+    SetReq.V_IR_RECEIVE: str,
+    SetReq.V_FLOW: str,
+    SetReq.V_VOLUME: str,
+    SetReq.V_LOCK_STATUS: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_DUST_LEVEL: str,
+    SetReq.V_VOLTAGE: str,
+    SetReq.V_CURRENT: str,
+}
+
+CONF_METRIC = 'M'
+CONF_IMPERIAL = 'I'
+MAX_NODE_ID = 254
+
+VALID_INTERNAL = {
+    Internal.I_BATTERY_LEVEL: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str)),
+    Internal.I_TIME: vol.Any('', vol.All(vol.Coerce(int), vol.Coerce(str))),
+    Internal.I_VERSION: str,
+    Internal.I_ID_REQUEST: '',
+    Internal.I_ID_RESPONSE: vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=MAX_NODE_ID), vol.Coerce(str)),
+    Internal.I_INCLUSION_MODE: vol.In([LOGICAL_ZERO, LOGICAL_ONE]),
+    Internal.I_CONFIG: vol.Any(
+        vol.All(vol.Coerce(int), vol.Range(min=0, max=MAX_NODE_ID)),
+        CONF_METRIC, CONF_IMPERIAL),
+    Internal.I_FIND_PARENT: '',
+    Internal.I_FIND_PARENT_RESPONSE: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=MAX_NODE_ID), vol.Coerce(str)),
+    Internal.I_LOG_MESSAGE: str,
+    Internal.I_CHILDREN: str,
+    Internal.I_SKETCH_NAME: str,
+    Internal.I_SKETCH_VERSION: str,
+    Internal.I_REBOOT: '',
+    Internal.I_GATEWAY_READY: str,
+}
+
+VALID_STREAM = {
+    Stream.ST_FIRMWARE_CONFIG_REQUEST: str,
+    Stream.ST_FIRMWARE_CONFIG_RESPONSE: str,
+    Stream.ST_FIRMWARE_REQUEST: str,
+    Stream.ST_FIRMWARE_RESPONSE: str,
+    Stream.ST_SOUND: str,
+    Stream.ST_IMAGE: str,
+}
+
+VALID_PAYLOADS = {
+    MessageType.presentation: VALID_PRESENTATION,
+    MessageType.set: VALID_SETREQ,
+    MessageType.req: {member: '' for member in list(SetReq)},
+    MessageType.internal: VALID_INTERNAL,
+    MessageType.stream: VALID_STREAM,
+}
 
 HANDLE_INTERNAL = {
     Internal.I_BATTERY_LEVEL: {

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -1,7 +1,14 @@
 """MySensors constants for version 1.5 of MySensors."""
+import binascii
 from enum import IntEnum
+
+import voluptuous as vol
+
 # pylint: disable=unused-import
-from mysensors.const_14 import HANDLE_INTERNAL  # noqa: F401
+from mysensors.const_14 import HANDLE_INTERNAL, MAX_NODE_ID  # noqa: F401
+from mysensors.const_14 import (AUTO_CHANGE_OVER, COOL_ON, FORECASTS, HEAT_ON,
+                                LOGICAL_ONE, LOGICAL_ZERO, OFF, VALID_INTERNAL,
+                                VALID_STREAM)
 
 
 class MessageType(IntEnum):
@@ -190,3 +197,191 @@ class Stream(IntEnum):
     ST_FIRMWARE_RESPONSE = 3  # Response FW block
     ST_SOUND = 4  # Sound
     ST_IMAGE = 5  # Image
+
+
+VALID_MESSAGE_TYPES = {
+    MessageType.presentation: list(Presentation),
+    MessageType.set: list(SetReq),
+    MessageType.req: list(SetReq),
+    MessageType.internal: list(Internal),
+    MessageType.stream: list(Stream),
+}
+
+VALID_PRESENTATION = {
+    member: str for member in list(Presentation)
+}
+
+VALID_TYPES = {
+    Presentation.S_DOOR: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_MOTION: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_SMOKE: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_BINARY: [SetReq.V_STATUS, SetReq.V_WATT],
+    Presentation.S_DIMMER: [
+        SetReq.V_STATUS, SetReq.V_PERCENTAGE, SetReq.V_WATT],
+    Presentation.S_COVER: [
+        SetReq.V_UP, SetReq.V_DOWN, SetReq.V_STOP, SetReq.V_DIMMER],
+    Presentation.S_TEMP: [SetReq.V_TEMP],
+    Presentation.S_HUM: [SetReq.V_HUM],
+    Presentation.S_BARO: [
+        SetReq.V_PRESSURE, SetReq.V_FORECAST],
+    Presentation.S_WIND: [
+        SetReq.V_WIND, SetReq.V_GUST, SetReq.V_DIRECTION],
+    Presentation.S_RAIN: [
+        SetReq.V_RAIN, SetReq.V_RAINRATE],
+    Presentation.S_UV: [SetReq.V_UV],
+    Presentation.S_WEIGHT: [
+        SetReq.V_WEIGHT, SetReq.V_IMPEDANCE],
+    Presentation.S_POWER: [SetReq.V_WATT, SetReq.V_KWH],
+    Presentation.S_HEATER: [SetReq.V_TEMP],
+    Presentation.S_DISTANCE: [SetReq.V_DISTANCE],
+    Presentation.S_LIGHT_LEVEL: [SetReq.V_LIGHT_LEVEL],
+    Presentation.S_ARDUINO_NODE: [],
+    Presentation.S_ARDUINO_REPEATER_NODE: [],
+    Presentation.S_LOCK: [SetReq.V_LOCK_STATUS],
+    Presentation.S_IR: [SetReq.V_IR_SEND, SetReq.V_IR_RECEIVE],
+    Presentation.S_WATER: [SetReq.V_FLOW, SetReq.V_VOLUME],
+    Presentation.S_AIR_QUALITY: [SetReq.V_DUST_LEVEL],
+    Presentation.S_CUSTOM: [
+        SetReq.V_VAR1, SetReq.V_VAR2, SetReq.V_VAR3, SetReq.V_VAR4,
+        SetReq.V_VAR5],
+    Presentation.S_DUST: [SetReq.V_DUST_LEVEL],
+    Presentation.S_SCENE_CONTROLLER: [SetReq.V_SCENE_ON, SetReq.V_SCENE_OFF],
+    Presentation.S_RGB_LIGHT: [SetReq.V_RGB, SetReq.V_WATT],
+    Presentation.S_RGBW_LIGHT: [SetReq.V_RGBW, SetReq.V_WATT],
+    Presentation.S_COLOR_SENSOR: [SetReq.V_RGB],
+    Presentation.S_HVAC: [
+        SetReq.V_STATUS, SetReq.V_TEMP, SetReq.V_HVAC_SETPOINT_HEAT,
+        SetReq.V_HVAC_SETPOINT_COOL, SetReq.V_HVAC_FLOW_STATE,
+        SetReq.V_HVAC_FLOW_MODE, SetReq.V_HVAC_SPEED],
+    Presentation.S_MULTIMETER: [
+        SetReq.V_VOLTAGE, SetReq.V_CURRENT, SetReq.V_IMPEDANCE],
+    Presentation.S_SPRINKLER: [SetReq.V_STATUS, SetReq.V_TRIPPED],
+    Presentation.S_WATER_LEAK: [SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_SOUND: [SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_VIBRATION: [
+        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_MOISTURE: [
+        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED],
+}
+
+
+def validate_hex(value):
+    """Validate that value has hex format."""
+    try:
+        binascii.unhexlify(value)
+    except Exception:
+        raise vol.Invalid(
+            '{} is not of hex format'.format(value))
+    return value
+
+
+def validate_v_rgb(value):
+    """Validate a V_RGB value."""
+    if len(value) != 6:
+        raise vol.Invalid(
+            '{} is not six characters long'.format(value))
+    return validate_hex(value)
+
+
+def validate_v_rgbw(value):
+    """Validate a V_RGBW value."""
+    if len(value) != 8:
+        raise vol.Invalid(
+            '{} is not eight characters long'.format(value))
+    return validate_hex(value)
+
+
+AUTO = 'Auto'
+MAX = 'Max'
+MIN = 'Min'
+NORMAL = 'Normal'
+
+# Define this again for version 1.5 to avoid conflicts with version 1.4.
+VALID_SETREQ = {
+    SetReq.V_TEMP: str,
+    SetReq.V_HUM: str,
+    SetReq.V_STATUS: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_PERCENTAGE: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        msg='value must be between {} and {}'.format(0, 100)),
+    SetReq.V_PRESSURE: str,
+    SetReq.V_FORECAST: vol.Any(str, vol.In(
+        FORECASTS,
+        msg='forecast must be one of: {}, {}, {}, {}, {}, {}'.format(
+            *FORECASTS))),
+    SetReq.V_RAIN: str,
+    SetReq.V_RAINRATE: str,
+    SetReq.V_WIND: str,
+    SetReq.V_GUST: str,
+    SetReq.V_DIRECTION: str,
+    SetReq.V_UV: str,
+    SetReq.V_WEIGHT: str,
+    SetReq.V_DISTANCE: str,
+    SetReq.V_IMPEDANCE: str,
+    SetReq.V_ARMED: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_TRIPPED: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_WATT: str,
+    SetReq.V_KWH: str,
+    SetReq.V_SCENE_ON: str,
+    SetReq.V_SCENE_OFF: str,
+    SetReq.V_HVAC_FLOW_STATE: vol.In(
+        [OFF, HEAT_ON, COOL_ON, AUTO_CHANGE_OVER],
+        msg='value must be one of: {}, {}, {} or {}'.format(
+            OFF, HEAT_ON, COOL_ON, AUTO_CHANGE_OVER)),
+    SetReq.V_HVAC_SPEED: vol.In(
+        [MIN, NORMAL, MAX, AUTO],
+        msg='value must be one of: {}, {}, {} or {}'.format(
+            MIN, NORMAL, MAX, AUTO)),
+    SetReq.V_LIGHT_LEVEL: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        msg='value must be between {} and {}'.format(0, 100)),
+    SetReq.V_VAR1: str,
+    SetReq.V_VAR2: str,
+    SetReq.V_VAR3: str,
+    SetReq.V_VAR4: str,
+    SetReq.V_VAR5: str,
+    SetReq.V_UP: str,
+    SetReq.V_DOWN: str,
+    SetReq.V_STOP: str,
+    SetReq.V_IR_SEND: str,
+    SetReq.V_IR_RECEIVE: str,
+    SetReq.V_FLOW: str,
+    SetReq.V_VOLUME: str,
+    SetReq.V_LOCK_STATUS: vol.In(
+        [LOGICAL_ZERO, LOGICAL_ONE],
+        msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
+    SetReq.V_LEVEL: str,
+    SetReq.V_VOLTAGE: str,
+    SetReq.V_CURRENT: str,
+    SetReq.V_RGB: vol.All(str, validate_v_rgb),
+    SetReq.V_RGBW: vol.All(str, validate_v_rgbw),
+    SetReq.V_ID: str,
+    SetReq.V_UNIT_PREFIX: str,
+    SetReq.V_HVAC_SETPOINT_COOL: vol.All(
+        vol.Coerce(float), vol.Range(min=0.0, max=100.0), vol.Coerce(str),
+        msg='value must be between {} and {}'.format(0.0, 100.0)),
+    SetReq.V_HVAC_SETPOINT_HEAT: vol.All(
+        vol.Coerce(float), vol.Range(min=0.0, max=100.0), vol.Coerce(str),
+        msg='value must be between {} and {}'.format(0.0, 100.0)),
+    SetReq.V_HVAC_FLOW_MODE: str,
+}
+
+VALID_INTERNAL.update({
+    Internal.I_REQUEST_SIGNING: str,
+    Internal.I_GET_NONCE: str,
+    Internal.I_GET_NONCE_RESPONSE: str,
+})
+
+VALID_PAYLOADS = {
+    MessageType.presentation: VALID_PRESENTATION,
+    MessageType.set: VALID_SETREQ,
+    MessageType.req: {member: '' for member in list(SetReq)},
+    MessageType.internal: VALID_INTERNAL,
+    MessageType.stream: VALID_STREAM,
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyserial==3.1.1
 IntelHex==2.1
 crcmod==1.7
+voluptuous==0.10.5

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ if os.path.exists('README.rst'):
 else:
     README = ''
 
+REQUIRES = [
+    'pyserial>=3.1.1', 'crcmod>=1.7', 'IntelHex>=2.1', 'voluptuous>=0.10.5',
+]
+
 setup(
     name='pymysensors',
     version='0.11.0.dev0',
@@ -16,7 +20,7 @@ setup(
     author='Theodor Lindquist',
     author_email='theodor.lindquist@gmail.com',
     license='MIT License',
-    install_requires=['pyserial>=3.1.1', 'crcmod>=1.7', 'IntelHex>=2.1'],
+    install_requires=REQUIRES,
     packages=find_packages(exclude=['tests', 'tests.*']),
     keywords=['sensor', 'actuator', 'IoT', 'DYI'],
     zip_safe=True,

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -528,13 +528,13 @@ class TestGateway(TestCase):
             0, self.gateway.const.Presentation.S_LIGHT_LEVEL)
         sensor.children[0].values[
             self.gateway.const.SetReq.V_LIGHT_LEVEL] = '43'
-        sensor.children[0].validate()
+        sensor.children[0].validate(self.gateway.protocol_version)
         self.assertEqual(
             sensor.children[0].values[self.gateway.const.SetReq.V_LIGHT_LEVEL],
             '43')
         sensor.children[0].values[self.gateway.const.SetReq.V_TRIPPED] = '1'
         with self.assertRaises(vol.Invalid):
-            sensor.children[0].validate()
+            sensor.children[0].validate(self.gateway.protocol_version)
 
     def test_set_forecast(self):
         """Test set of V_FORECAST."""


### PR DESCRIPTION
POTENTIALLY BREAKING CHANGE: Users that are not adhering to the mysensors serial api could face dropped messages after this change. Messages must follow the mysensors api implemented as in pymysensors after this change.

* Add valid types in const.
* Add message validation, using voluptuous, called in logic and set_child_value methods.
* Add child method validate for child value types and child values.
  * This method is not used internally, but for use by user of API.
* Add child method get_schema, to get a voluptuous schema for the child.
* Handle persistence and fix pickle persistence.
* Allow custom forecast values.
* Add tests.