### PR TITLE
Update type schema and add message tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+exclude_lines =
+    # need to re-specify the default pragma
+    pragma: no cover
+
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -600,6 +600,11 @@ class Message(object):
                 [SYSTEM_CHILD_ID],
                 msg='When message type is {}, child_id must be {}'.format(
                     self.type, SYSTEM_CHILD_ID)))
+        if (self.type == const.MessageType.internal and
+                self.sub_type in [
+                    const.Internal.I_ID_REQUEST,
+                    const.Internal.I_ID_RESPONSE]):
+            valid_child_ids = vol.Coerce(int)
         valid_types = vol.All(vol.Coerce(int), vol.In(
             [member.value for member in const.VALID_MESSAGE_TYPES],
             msg='Not valid message type: {}'.format(self.type)))

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -184,7 +184,8 @@ VALID_TYPES = {
     Presentation.S_WEIGHT: [
         SetReq.V_WEIGHT, SetReq.V_IMPEDANCE],
     Presentation.S_POWER: [SetReq.V_WATT, SetReq.V_KWH],
-    Presentation.S_HEATER: [SetReq.V_TEMP],
+    Presentation.S_HEATER: [
+        SetReq.V_HEATER, SetReq.V_HEATER_SW, SetReq.V_TEMP],
     Presentation.S_DISTANCE: [SetReq.V_DISTANCE],
     Presentation.S_LIGHT_LEVEL: [SetReq.V_LIGHT_LEVEL],
     Presentation.S_ARDUINO_NODE: [],

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -384,6 +384,7 @@ VALID_SETREQ = {
     SetReq.V_HVAC_FLOW_MODE: str,
 }
 
+VALID_INTERNAL = dict(VALID_INTERNAL)
 VALID_INTERNAL.update({
     Internal.I_REQUEST_SIGNING: str,
     Internal.I_GET_NONCE: str,

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -220,7 +220,7 @@ VALID_TYPES = {
         SetReq.V_STATUS, SetReq.V_PERCENTAGE, SetReq.V_WATT],
     Presentation.S_COVER: [
         SetReq.V_UP, SetReq.V_DOWN, SetReq.V_STOP, SetReq.V_PERCENTAGE],
-    Presentation.S_TEMP: [SetReq.V_TEMP],
+    Presentation.S_TEMP: [SetReq.V_TEMP, SetReq.V_ID],
     Presentation.S_HUM: [SetReq.V_HUM],
     Presentation.S_BARO: [
         SetReq.V_PRESSURE, SetReq.V_FORECAST],
@@ -232,9 +232,11 @@ VALID_TYPES = {
     Presentation.S_WEIGHT: [
         SetReq.V_WEIGHT, SetReq.V_IMPEDANCE],
     Presentation.S_POWER: [SetReq.V_WATT, SetReq.V_KWH],
-    Presentation.S_HEATER: [SetReq.V_TEMP],
-    Presentation.S_DISTANCE: [SetReq.V_DISTANCE],
-    Presentation.S_LIGHT_LEVEL: [SetReq.V_LIGHT_LEVEL],
+    Presentation.S_HEATER: [
+        SetReq.V_STATUS, SetReq.V_TEMP, SetReq.V_HVAC_SETPOINT_HEAT,
+        SetReq.V_HVAC_FLOW_STATE],
+    Presentation.S_DISTANCE: [SetReq.V_DISTANCE],  # FIXME: unit prefix where?
+    Presentation.S_LIGHT_LEVEL: [SetReq.V_LIGHT_LEVEL, SetReq.V_LEVEL],
     Presentation.S_ARDUINO_NODE: [],
     Presentation.S_ARDUINO_REPEATER_NODE: [],
     Presentation.S_LOCK: [SetReq.V_LOCK_STATUS],

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -220,52 +220,60 @@ VALID_TYPES = {
         SetReq.V_STATUS, SetReq.V_PERCENTAGE, SetReq.V_WATT],
     Presentation.S_COVER: [
         SetReq.V_UP, SetReq.V_DOWN, SetReq.V_STOP, SetReq.V_PERCENTAGE],
-    Presentation.S_TEMP: [SetReq.V_TEMP, SetReq.V_ID],
-    Presentation.S_HUM: [SetReq.V_HUM],
+    Presentation.S_TEMP: [SetReq.V_TEMP, SetReq.V_ID, SetReq.V_UNIT_PREFIX],
+    Presentation.S_HUM: [SetReq.V_HUM, SetReq.V_UNIT_PREFIX],
     Presentation.S_BARO: [
-        SetReq.V_PRESSURE, SetReq.V_FORECAST],
+        SetReq.V_PRESSURE, SetReq.V_FORECAST, SetReq.V_UNIT_PREFIX],
     Presentation.S_WIND: [
-        SetReq.V_WIND, SetReq.V_GUST, SetReq.V_DIRECTION],
+        SetReq.V_WIND, SetReq.V_GUST, SetReq.V_DIRECTION,
+        SetReq.V_UNIT_PREFIX],
     Presentation.S_RAIN: [
-        SetReq.V_RAIN, SetReq.V_RAINRATE],
-    Presentation.S_UV: [SetReq.V_UV],
+        SetReq.V_RAIN, SetReq.V_RAINRATE, SetReq.V_UNIT_PREFIX],
+    Presentation.S_UV: [SetReq.V_UV, SetReq.V_UNIT_PREFIX],
     Presentation.S_WEIGHT: [
-        SetReq.V_WEIGHT, SetReq.V_IMPEDANCE],
-    Presentation.S_POWER: [SetReq.V_WATT, SetReq.V_KWH],
+        SetReq.V_WEIGHT, SetReq.V_IMPEDANCE, SetReq.V_UNIT_PREFIX],
+    Presentation.S_POWER: [SetReq.V_WATT, SetReq.V_KWH, SetReq.V_UNIT_PREFIX],
     Presentation.S_HEATER: [
         SetReq.V_STATUS, SetReq.V_TEMP, SetReq.V_HVAC_SETPOINT_HEAT,
         SetReq.V_HVAC_FLOW_STATE],
-    Presentation.S_DISTANCE: [SetReq.V_DISTANCE],  # FIXME: unit prefix where?
-    Presentation.S_LIGHT_LEVEL: [SetReq.V_LIGHT_LEVEL, SetReq.V_LEVEL],
+    Presentation.S_DISTANCE: [SetReq.V_DISTANCE, SetReq.V_UNIT_PREFIX],
+    Presentation.S_LIGHT_LEVEL: [
+        SetReq.V_LIGHT_LEVEL, SetReq.V_LEVEL, SetReq.V_UNIT_PREFIX],
     Presentation.S_ARDUINO_NODE: [],
     Presentation.S_ARDUINO_REPEATER_NODE: [],
     Presentation.S_LOCK: [SetReq.V_LOCK_STATUS],
     Presentation.S_IR: [SetReq.V_IR_SEND, SetReq.V_IR_RECEIVE],
-    Presentation.S_WATER: [SetReq.V_FLOW, SetReq.V_VOLUME],
-    Presentation.S_AIR_QUALITY: [SetReq.V_LEVEL],
+    Presentation.S_WATER: [
+        SetReq.V_FLOW, SetReq.V_VOLUME, SetReq.V_UNIT_PREFIX],
+    Presentation.S_AIR_QUALITY: [SetReq.V_LEVEL, SetReq.V_UNIT_PREFIX],
     Presentation.S_CUSTOM: [
         SetReq.V_VAR1, SetReq.V_VAR2, SetReq.V_VAR3, SetReq.V_VAR4,
-        SetReq.V_VAR5],
-    Presentation.S_DUST: [SetReq.V_LEVEL],
+        SetReq.V_VAR5, SetReq.V_UNIT_PREFIX],
+    Presentation.S_DUST: [SetReq.V_LEVEL, SetReq.V_UNIT_PREFIX],
     Presentation.S_SCENE_CONTROLLER: [SetReq.V_SCENE_ON, SetReq.V_SCENE_OFF],
     Presentation.S_RGB_LIGHT: [
         SetReq.V_RGB, SetReq.V_WATT, SetReq.V_PERCENTAGE],
     Presentation.S_RGBW_LIGHT: [
         SetReq.V_RGBW, SetReq.V_WATT, SetReq.V_PERCENTAGE],
-    Presentation.S_COLOR_SENSOR: [SetReq.V_RGB],
+    Presentation.S_COLOR_SENSOR: [SetReq.V_RGB, SetReq.V_UNIT_PREFIX],
     Presentation.S_HVAC: [
         SetReq.V_STATUS, SetReq.V_TEMP, SetReq.V_HVAC_SETPOINT_HEAT,
         SetReq.V_HVAC_SETPOINT_COOL, SetReq.V_HVAC_FLOW_STATE,
         SetReq.V_HVAC_FLOW_MODE, SetReq.V_HVAC_SPEED],
     Presentation.S_MULTIMETER: [
-        SetReq.V_VOLTAGE, SetReq.V_CURRENT, SetReq.V_IMPEDANCE],
+        SetReq.V_VOLTAGE, SetReq.V_CURRENT, SetReq.V_IMPEDANCE,
+        SetReq.V_UNIT_PREFIX],
     Presentation.S_SPRINKLER: [SetReq.V_STATUS, SetReq.V_TRIPPED],
     Presentation.S_WATER_LEAK: [SetReq.V_TRIPPED, SetReq.V_ARMED],
-    Presentation.S_SOUND: [SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED],
+    Presentation.S_SOUND: [
+        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED,
+        SetReq.V_UNIT_PREFIX],
     Presentation.S_VIBRATION: [
-        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED],
+        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED,
+        SetReq.V_UNIT_PREFIX],
     Presentation.S_MOISTURE: [
-        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED],
+        SetReq.V_LEVEL, SetReq.V_TRIPPED, SetReq.V_ARMED,
+        SetReq.V_UNIT_PREFIX],
 }
 
 

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -136,7 +136,7 @@ class SetReq(IntEnum):
     V_HVAC_SETPOINT_COOL = 44   # HVAC cold setpoint (Integer between 0-100)
     V_HVAC_SETPOINT_HEAT = 45   # HVAC/Heater setpoint (Integer between 0-100)
     # Flow mode for HVAC ("Auto", "ContinuousOn", "PeriodicOn")
-    V_HVAC_FLOW_MODE = 45
+    V_HVAC_FLOW_MODE = 46
 
 
 class Internal(IntEnum):
@@ -219,7 +219,7 @@ VALID_TYPES = {
     Presentation.S_DIMMER: [
         SetReq.V_STATUS, SetReq.V_PERCENTAGE, SetReq.V_WATT],
     Presentation.S_COVER: [
-        SetReq.V_UP, SetReq.V_DOWN, SetReq.V_STOP, SetReq.V_DIMMER],
+        SetReq.V_UP, SetReq.V_DOWN, SetReq.V_STOP, SetReq.V_PERCENTAGE],
     Presentation.S_TEMP: [SetReq.V_TEMP],
     Presentation.S_HUM: [SetReq.V_HUM],
     Presentation.S_BARO: [
@@ -240,14 +240,16 @@ VALID_TYPES = {
     Presentation.S_LOCK: [SetReq.V_LOCK_STATUS],
     Presentation.S_IR: [SetReq.V_IR_SEND, SetReq.V_IR_RECEIVE],
     Presentation.S_WATER: [SetReq.V_FLOW, SetReq.V_VOLUME],
-    Presentation.S_AIR_QUALITY: [SetReq.V_DUST_LEVEL],
+    Presentation.S_AIR_QUALITY: [SetReq.V_LEVEL],
     Presentation.S_CUSTOM: [
         SetReq.V_VAR1, SetReq.V_VAR2, SetReq.V_VAR3, SetReq.V_VAR4,
         SetReq.V_VAR5],
-    Presentation.S_DUST: [SetReq.V_DUST_LEVEL],
+    Presentation.S_DUST: [SetReq.V_LEVEL],
     Presentation.S_SCENE_CONTROLLER: [SetReq.V_SCENE_ON, SetReq.V_SCENE_OFF],
-    Presentation.S_RGB_LIGHT: [SetReq.V_RGB, SetReq.V_WATT],
-    Presentation.S_RGBW_LIGHT: [SetReq.V_RGBW, SetReq.V_WATT],
+    Presentation.S_RGB_LIGHT: [
+        SetReq.V_RGB, SetReq.V_WATT, SetReq.V_PERCENTAGE],
+    Presentation.S_RGBW_LIGHT: [
+        SetReq.V_RGBW, SetReq.V_WATT, SetReq.V_PERCENTAGE],
     Presentation.S_COLOR_SENSOR: [SetReq.V_RGB],
     Presentation.S_HVAC: [
         SetReq.V_STATUS, SetReq.V_TEMP, SetReq.V_HVAC_SETPOINT_HEAT,

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -224,10 +224,13 @@ class Internal(IntEnum):
     I_GATEWAY_READY = 14
     # Provides signing related preferences (first byte is preference version).
     I_SIGNING_PRESENTATION = 15
+    I_REQUEST_SIGNING = 15  # alias from version 1.5
     # Request for a nonce.
     I_NONCE_REQUEST = 16
+    I_GET_NONCE = 16  # alias from version 1.5
     # Payload is nonce data.
     I_NONCE_RESPONSE = 17
+    I_GET_NONCE_RESPONSE = 17  # alias from version 1.5
     I_HEARTBEAT = 18
     I_PRESENTATION = 19
     I_DISCOVER = 20
@@ -268,6 +271,7 @@ VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
 
+VALID_TYPES = dict(VALID_TYPES)
 VALID_TYPES.update({
     Presentation.S_POWER: [
         SetReq.V_WATT, SetReq.V_KWH, SetReq.V_VAR, SetReq.V_VA,
@@ -299,6 +303,7 @@ def validate_gps(value):
     return value
 
 
+VALID_SETREQ = dict(VALID_SETREQ)
 VALID_SETREQ.update({
     SetReq.V_TEXT: str,
     SetReq.V_CUSTOM: str,
@@ -314,11 +319,13 @@ VALID_SETREQ.update({
         msg='value should be between -1.0 and 1.0'),
 })
 
+VALID_INTERNAL = dict(VALID_INTERNAL)
 VALID_INTERNAL.update({
     Internal.I_HEARTBEAT: '',
     Internal.I_PRESENTATION: '',
     Internal.I_DISCOVER: '',
-    Internal.I_DISCOVER_RESPONSE: str,
+    Internal.I_DISCOVER_RESPONSE: vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=MAX_NODE_ID), vol.Coerce(str)),
     Internal.I_HEARTBEAT_RESPONSE: str,
     Internal.I_LOCKED: str,
     Internal.I_PING: vol.All(vol.Coerce(int), vol.Coerce(str)),
@@ -336,6 +343,7 @@ VALID_PAYLOADS = {
     MessageType.stream: VALID_STREAM,
 }
 
+HANDLE_INTERNAL = dict(HANDLE_INTERNAL)
 HANDLE_INTERNAL.update({
     Internal.I_GATEWAY_READY: {
         'log': 'info', 'msg': {

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -271,18 +271,18 @@ VALID_PRESENTATION = {
 VALID_TYPES.update({
     Presentation.S_POWER: [
         SetReq.V_WATT, SetReq.V_KWH, SetReq.V_VAR, SetReq.V_VA,
-        SetReq.V_POWER_FACTOR],
+        SetReq.V_POWER_FACTOR, SetReq.V_UNIT_PREFIX],
     Presentation.S_IR: [
         SetReq.V_IR_SEND, SetReq.V_IR_RECEIVE, SetReq.V_IR_RECORD],
     Presentation.S_CUSTOM: [
         SetReq.V_VAR1, SetReq.V_VAR2, SetReq.V_VAR3, SetReq.V_VAR4,
-        SetReq.V_VAR5, SetReq.V_CUSTOM],
+        SetReq.V_VAR5, SetReq.V_CUSTOM, SetReq.V_UNIT_PREFIX],
     Presentation.S_INFO: [SetReq.V_TEXT],
-    Presentation.S_GAS: [SetReq.V_FLOW, SetReq.V_VOLUME],
+    Presentation.S_GAS: [SetReq.V_FLOW, SetReq.V_VOLUME, SetReq.V_UNIT_PREFIX],
     Presentation.S_GPS: [SetReq.V_POSITION],
     Presentation.S_WATER_QUALITY: [
         SetReq.V_TEMP, SetReq.V_PH, SetReq.V_ORP, SetReq.V_EC,
-        SetReq.V_STATUS],
+        SetReq.V_STATUS, SetReq.V_UNIT_PREFIX],
 })
 
 

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -269,6 +269,14 @@ VALID_PRESENTATION = {
 }
 
 VALID_TYPES.update({
+    Presentation.S_POWER: [
+        SetReq.V_WATT, SetReq.V_KWH, SetReq.V_VAR, SetReq.V_VA,
+        SetReq.V_POWER_FACTOR],
+    Presentation.S_IR: [
+        SetReq.V_IR_SEND, SetReq.V_IR_RECEIVE, SetReq.V_IR_RECORD],
+    Presentation.S_CUSTOM: [
+        SetReq.V_VAR1, SetReq.V_VAR2, SetReq.V_VAR3, SetReq.V_VAR4,
+        SetReq.V_VAR5, SetReq.V_CUSTOM],
     Presentation.S_INFO: [SetReq.V_TEXT],
     Presentation.S_GAS: [SetReq.V_FLOW, SetReq.V_VOLUME],
     Presentation.S_GPS: [SetReq.V_POSITION],

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,194 @@
+"""Test mysensors messages."""
+from unittest import TestCase
+
+from mysensors import get_const, Message
+from mysensors.const_14 import Internal, MessageType
+
+SET_FIXTURES_14 = {
+    'V_TEMP': '20.0',
+    'V_HUM': '30',
+    'V_LIGHT': '1',
+    'V_DIMMER': '99',
+    'V_PRESSURE': '101325',
+    'V_FORECAST': 'stable',
+    'V_RAIN': '30',
+    'V_RAINRATE': '2',
+    'V_WIND': '10',
+    'V_GUST': '20',
+    'V_DIRECTION': '270',
+    'V_UV': '7',
+    'V_WEIGHT': '10',
+    'V_DISTANCE': '100',
+    'V_IMPEDANCE': '10',
+    'V_ARMED': '1',
+    'V_TRIPPED': '1',
+    'V_WATT': '1000',
+    'V_KWH': '20',
+    'V_SCENE_ON': 'scene_3',
+    'V_SCENE_OFF': 'scene_4',
+    'V_HEATER': 'AutoChangeOver',
+    'V_HEATER_SW': '1',
+    'V_LIGHT_LEVEL': '99',
+    'V_VAR1': 'test1',
+    'V_VAR2': 'test2',
+    'V_VAR3': 'test3',
+    'V_VAR4': 'test4',
+    'V_VAR5': 'test5',
+    'V_UP': '',
+    'V_DOWN': '',
+    'V_STOP': '',
+    'V_IR_SEND': 'code',
+    'V_IR_RECEIVE': 'code',
+    'V_FLOW': '1.5',
+    'V_VOLUME': '3.0',
+    'V_LOCK_STATUS': '1',
+    'V_DUST_LEVEL': '80',
+    'V_VOLTAGE': '3.3',
+    'V_CURRENT': '1.2',
+}
+
+SET_FIXTURES_15 = dict(SET_FIXTURES_14)
+SET_FIXTURES_15.update({
+    'V_STATUS': '1',
+    'V_PERCENTAGE': '99',
+    'V_HVAC_FLOW_STATE': 'AutoChangeOver',
+    'V_HVAC_SPEED': 'Auto',
+    'V_LEVEL': '89',
+    'V_RGB': 'ffffff',
+    'V_RGBW': 'ffffffff',
+    'V_ID': '1',
+    'V_UNIT_PREFIX': 'mV',
+    'V_HVAC_SETPOINT_COOL': '24.0',
+    'V_HVAC_SETPOINT_HEAT': '20.0',
+    'V_HVAC_FLOW_MODE': 'Auto',
+})
+SET_FIXTURES_15.pop('V_HEATER')
+SET_FIXTURES_15.pop('V_HEATER_SW')
+
+SET_FIXTURES_20 = dict(SET_FIXTURES_15)
+SET_FIXTURES_20.update({
+    'V_TEXT': 'test text',
+    'V_CUSTOM': 'test custom',
+    'V_POSITION': '10.0,10.0,10.0',
+    'V_IR_RECORD': 'code_id_to_store',
+    'V_PH': '7.0',
+    'V_ORP': '300',
+    'V_EC': '5.5',
+    'V_VAR': '100',
+    'V_VA': '500',
+    'V_POWER_FACTOR': '0.9',
+})
+
+INTERNAL_FIXTURES_14 = {
+    'I_BATTERY_LEVEL': '99',
+    'I_TIME': '1500000000',
+    'I_VERSION': '1.4.1',
+    'I_ID_REQUEST': '',
+    'I_ID_RESPONSE': '254',
+    'I_INCLUSION_MODE': '1',
+    'I_CONFIG': 'M',
+    'I_FIND_PARENT': '',
+    'I_FIND_PARENT_RESPONSE': '254',
+    'I_LOG_MESSAGE': 'test log message',
+    'I_CHILDREN': 'C',  # clear routing data for the node
+    'I_SKETCH_NAME': 'test sketch name',
+    'I_SKETCH_VERSION': '1.0.0',
+    'I_REBOOT': '',
+    'I_GATEWAY_READY': 'Gateway startup complete.',
+}
+
+INTERNAL_FIXTURES_15 = dict(INTERNAL_FIXTURES_14)
+INTERNAL_FIXTURES_15.update({
+    'I_REQUEST_SIGNING': 'test signing request',
+    'I_GET_NONCE': 'test get nonce',
+    'I_GET_NONCE_RESPONSE': 'test get nonce response',
+})
+
+INTERNAL_FIXTURES_20 = dict(INTERNAL_FIXTURES_15)
+INTERNAL_FIXTURES_20.update({
+    'I_HEARTBEAT': '',
+    'I_PRESENTATION': '',
+    'I_DISCOVER': '',
+    'I_DISCOVER_RESPONSE': '254',
+    'I_HEARTBEAT_RESPONSE': '123465',
+    'I_LOCKED': 'TMFV',
+    'I_PING': '123456',
+    'I_PONG': '123456',
+    'I_REGISTRATION_REQUEST': '2.0.0',
+    'I_REGISTRATION_RESPONSE': '1',
+    'I_DEBUG': 'test debug',
+})
+
+
+class TestMessage(TestCase):
+    """Test the Message class and it's encode/decode functions."""
+
+    def test_encode(self):
+        """Test encode of message."""
+        msg = Message()
+        cmd = msg.encode()
+        self.assertEqual(cmd, '0;0;0;0;0;\n')
+
+        msg.node_id = 1
+        msg.child_id = 255
+        msg.type = MessageType.internal
+        msg.sub_type = Internal.I_BATTERY_LEVEL
+        msg.ack = 0
+        msg.payload = 57
+
+        cmd = msg.encode()
+        self.assertEqual(cmd, '1;255;3;0;0;57\n')
+
+    def test_encode_bad_message(self):
+        """Test encode of bad message."""
+        msg = Message()
+        msg.sub_type = 'bad'
+        cmd = msg.encode()
+        self.assertEqual(cmd, None)
+
+    def test_decode(self):
+        """Test decode of message."""
+        msg = Message('1;255;3;0;0;57\n')
+        self.assertEqual(msg.node_id, 1)
+        self.assertEqual(msg.child_id, 255)
+        self.assertEqual(msg.type, MessageType.internal)
+        self.assertEqual(msg.sub_type, Internal.I_BATTERY_LEVEL)
+        self.assertEqual(msg.ack, 0)
+        self.assertEqual(msg.payload, '57')
+
+    def test_decode_bad_message(self):
+        """Test decode of bad message."""
+        with self.assertRaises(ValueError):
+            Message('bad;bad;bad;bad;bad;bad\n')
+
+
+def test_validate_set():
+    """Test Set messages."""
+    versions = [
+        ('1.4', SET_FIXTURES_14), ('1.5', SET_FIXTURES_15),
+        ('2.0', SET_FIXTURES_20)]
+    for protocol_version, fixture in versions:
+        const = get_const(protocol_version)
+        for name, payload in fixture.items():
+            sub_type = const.SetReq[name]
+            msg = Message('1;0;1;0;{};{}\n'.format(sub_type, payload))
+            valid = msg.validate(protocol_version)
+            assert valid == {
+                'node_id': 1, 'child_id': 0, 'type': 1, 'ack': 0,
+                'sub_type': sub_type, 'payload': payload}
+
+
+def test_validate_internal():
+    """Test Internal messages."""
+    versions = [
+        ('1.4', INTERNAL_FIXTURES_14), ('1.5', INTERNAL_FIXTURES_15),
+        ('2.0', INTERNAL_FIXTURES_20)]
+    for protocol_version, fixture in versions:
+        const = get_const(protocol_version)
+        for name, payload in fixture.items():
+            sub_type = const.Internal[name]
+            msg = Message('1;255;3;0;{};{}\n'.format(sub_type, payload))
+            valid = msg.validate(protocol_version)
+            assert valid == {
+                'node_id': 1, 'child_id': 255, 'type': 3, 'ack': 0,
+                'sub_type': sub_type, 'payload': payload}

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from mysensors import (ChildSensor, Gateway, Message, MySensorsJSONEncoder,
                        Sensor)
-from mysensors.const_14 import Internal, MessageType
 
 
 class TestGateway(TestCase):
@@ -734,7 +733,7 @@ class TestGateway20(TestGateway):
         self.gateway.logic('1;255;3;0;21;0')
         assert mock_is_sensor.called
 
-    def test_set_rgbw(self):
+    def test_set_position(self):
         """Test set of V_POSITION."""
         sensor = self._add_sensor(1)
         sensor.protocol_version = '2.0'
@@ -752,48 +751,6 @@ class TestGateway20(TestGateway):
         self.assertEqual(
             sensor.children[0].values[self.gateway.const.SetReq.V_POSITION],
             '10.0,10.0,10.0')
-
-
-class TestMessage(TestCase):
-    """Test the Message class and it's encode/decode functions."""
-
-    def test_encode(self):
-        """Test encode of message."""
-        msg = Message()
-        cmd = msg.encode()
-        self.assertEqual(cmd, '0;0;0;0;0;\n')
-
-        msg.node_id = 255
-        msg.child_id = 255
-        msg.type = MessageType.internal
-        msg.sub_type = Internal.I_BATTERY_LEVEL
-        msg.ack = 0
-        msg.payload = 57
-
-        cmd = msg.encode()
-        self.assertEqual(cmd, '255;255;3;0;0;57\n')
-
-    def test_encode_bad_message(self):
-        """Test encode of bad message."""
-        msg = Message()
-        msg.sub_type = 'bad'
-        cmd = msg.encode()
-        self.assertEqual(cmd, None)
-
-    def test_decode(self):
-        """Test decode of message."""
-        msg = Message('255;255;3;0;0;57\n')
-        self.assertEqual(msg.node_id, 255)
-        self.assertEqual(msg.child_id, 255)
-        self.assertEqual(msg.type, MessageType.internal)
-        self.assertEqual(msg.sub_type, Internal.I_BATTERY_LEVEL)
-        self.assertEqual(msg.ack, 0)
-        self.assertEqual(msg.payload, '57')
-
-    def test_decode_bad_message(self):
-        """Test decode of bad message."""
-        with self.assertRaises(ValueError):
-            Message('bad;bad;bad;bad;bad;bad\n')
 
 
 class MySensorsJSONEncoderTestUpgrade(MySensorsJSONEncoder):


### PR DESCRIPTION
* Fix const and type validation.
* Add more type mappings.
* Add unit prefix.
* Add .coveragerc.
* Breakout message tests into own module.
* Add valid Set and Internal message fixtures.
* Handle new format for node id requests with random number as child id.
* Fix name of test.
* Add some aliases for version 2.0 internal message const.