### PR TITLE
Fix protocol version null and enhance validation

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -15,6 +15,7 @@ from timeit import default_timer as timer
 
 import voluptuous as vol
 
+from .validation import is_battery_level, is_version
 from .ota import OTAFirmware
 from .version import __version__  # noqa: F401
 
@@ -27,7 +28,7 @@ SYSTEM_CHILD_ID = 255
 
 def get_const(protocol_version):
     """Return the const module for the protocol_version."""
-    version = str(protocol_version)
+    version = protocol_version
     if parse_ver('1.5') <= parse_ver(version) < parse_ver('2.0'):
         path = 'mysensors.const_15'
     elif parse_ver(version) >= parse_ver('2.0'):
@@ -57,7 +58,13 @@ class Gateway(object):
         self.persistence = persistence  # if true - save sensors to disk
         self.persistence_file = persistence_file  # path to persistence file
         self.persistence_bak = '{}.bak'.format(self.persistence_file)
-        self.protocol_version = protocol_version
+        try:
+            self.protocol_version = is_version(protocol_version)
+        except vol.Invalid as exc:
+            _LOGGER.warning(exc)
+            self.protocol_version = '1.4'
+            _LOGGER.info(
+                'Falling back to protocol version %s', self.protocol_version)
         self.const = get_const(self.protocol_version)
         self.ota = OTAFirmware(self.sensors, self.const)
         if persistence:
@@ -432,10 +439,23 @@ class Sensor(object):
         self.sketch_name = None
         self.sketch_version = None
         self._battery_level = 0
-        self.protocol_version = '1.4'
+        self._protocol_version = '1.4'
         self.new_state = {}
         self.queue = deque()
         self.reboot = False
+
+    def __getstate__(self):
+        """Get state to save as pickle."""
+        state = self.__dict__.copy()
+        for attr in ('_battery_level', '_protocol_version'):
+            value = state.pop(attr, None)
+            prop = attr
+            if prop.startswith('_'):
+                prop = prop[1:]
+            if value is not None:
+                state[prop] = value
+
+        return state
 
     def __setstate__(self, state):
         """Set state when loading pickle."""
@@ -460,7 +480,23 @@ class Sensor(object):
     @battery_level.setter
     def battery_level(self, value):
         """Set battery level as int."""
-        self._battery_level = int(value)
+        self._battery_level = is_battery_level(value)
+
+    @property
+    def protocol_version(self):
+        """Return protocol version."""
+        return self._protocol_version
+
+    @protocol_version.setter
+    def protocol_version(self, value):
+        """Set protocol version."""
+        try:
+            self._protocol_version = is_version(value)
+        except vol.Invalid as exc:
+            _LOGGER.warning(exc)
+            self._protocol_version = '1.4'
+            _LOGGER.info(
+                'Falling back to protocol version %s', self._protocol_version)
 
     def add_child_sensor(self, child_id, child_type, description=''):
         """Create and add a child sensor."""
@@ -664,7 +700,7 @@ class MySensorsJSONEncoder(json.JSONEncoder):
                 'type': obj.type,
                 'sketch_name': obj.sketch_name,
                 'sketch_version': obj.sketch_version,
-                '_battery_level': obj.battery_level,
+                'battery_level': obj.battery_level,
                 'protocol_version': obj.protocol_version,
             }
         if isinstance(obj, ChildSensor):

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -228,7 +228,7 @@ VALID_SETREQ = {
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_DIMMER: vol.All(
         percent_int, vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        msg='value must be integer between {} and {}'.format(0, 100)),
     SetReq.V_PRESSURE: str,
     SetReq.V_FORECAST: vol.Any(str, vol.In(
         FORECASTS,
@@ -261,8 +261,8 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_LIGHT_LEVEL: vol.All(
-        percent_int, vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        vol.Coerce(float), vol.Range(min=0.0, max=100.0), vol.Coerce(str),
+        msg='value must be float between {} and {}'.format(0.0, 100.0)),
     SetReq.V_VAR1: str,
     SetReq.V_VAR2: str,
     SetReq.V_VAR3: str,
@@ -289,7 +289,8 @@ MAX_NODE_ID = 254
 
 VALID_INTERNAL = {
     Internal.I_BATTERY_LEVEL: vol.All(
-        percent_int, vol.Coerce(str)),
+        percent_int, vol.Coerce(str),
+        msg='value must be integer between {} and {}'.format(0, 100)),
     Internal.I_TIME: vol.Any('', vol.All(vol.Coerce(int), vol.Coerce(str))),
     Internal.I_VERSION: str,
     Internal.I_ID_REQUEST: '',

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -3,6 +3,8 @@ from enum import IntEnum
 
 import voluptuous as vol
 
+from mysensors.validation import is_version, percent_int
+
 
 class MessageType(IntEnum):
     """MySensors message types."""
@@ -163,6 +165,9 @@ VALID_MESSAGE_TYPES = {
 VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
+VALID_PRESENTATION.update({
+    Presentation.S_ARDUINO_NODE: is_version,
+    Presentation.S_ARDUINO_RELAY: is_version})
 
 VALID_TYPES = {
     Presentation.S_DOOR: [SetReq.V_TRIPPED, SetReq.V_ARMED],
@@ -222,7 +227,7 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_DIMMER: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        percent_int, vol.Coerce(str),
         msg='value must be between {} and {}'.format(0, 100)),
     SetReq.V_PRESSURE: str,
     SetReq.V_FORECAST: vol.Any(str, vol.In(
@@ -256,7 +261,7 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_LIGHT_LEVEL: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        percent_int, vol.Coerce(str),
         msg='value must be between {} and {}'.format(0, 100)),
     SetReq.V_VAR1: str,
     SetReq.V_VAR2: str,
@@ -284,7 +289,7 @@ MAX_NODE_ID = 254
 
 VALID_INTERNAL = {
     Internal.I_BATTERY_LEVEL: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str)),
+        percent_int, vol.Coerce(str)),
     Internal.I_TIME: vol.Any('', vol.All(vol.Coerce(int), vol.Coerce(str))),
     Internal.I_VERSION: str,
     Internal.I_ID_REQUEST: '',

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -323,7 +323,7 @@ VALID_SETREQ = {
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_PERCENTAGE: vol.All(
         percent_int, vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        msg='value must be integer between {} and {}'.format(0, 100)),
     SetReq.V_PRESSURE: str,
     SetReq.V_FORECAST: vol.Any(str, vol.In(
         FORECASTS,
@@ -357,8 +357,8 @@ VALID_SETREQ = {
         msg='value must be one of: {}, {}, {} or {}'.format(
             MIN, NORMAL, MAX, AUTO)),
     SetReq.V_LIGHT_LEVEL: vol.All(
-        percent_int, vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        vol.Coerce(float), vol.Range(min=0.0, max=100.0), vol.Coerce(str),
+        msg='value must be float between {} and {}'.format(0.0, 100.0)),
     SetReq.V_VAR1: str,
     SetReq.V_VAR2: str,
     SetReq.V_VAR3: str,

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -9,6 +9,7 @@ from mysensors.const_14 import HANDLE_INTERNAL, MAX_NODE_ID  # noqa: F401
 from mysensors.const_14 import (AUTO_CHANGE_OVER, COOL_ON, FORECASTS, HEAT_ON,
                                 LOGICAL_ONE, LOGICAL_ZERO, OFF, VALID_INTERNAL,
                                 VALID_STREAM)
+from mysensors.validation import is_version, percent_int
 
 
 class MessageType(IntEnum):
@@ -46,6 +47,7 @@ class Presentation(IntEnum):
     S_LIGHT_LEVEL = 16              # Light sensor
     S_ARDUINO_NODE = 17             # Arduino node device
     S_ARDUINO_REPEATER_NODE = 18    # Arduino repeating node device
+    S_ARDUINO_RELAY = 18            # Alias for compatability
     S_LOCK = 19                     # Lock device
     S_IR = 20                       # Ir sender/receiver device
     S_WATER = 21                    # Water meter
@@ -210,6 +212,10 @@ VALID_MESSAGE_TYPES = {
 VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
+VALID_PRESENTATION.update({
+    Presentation.S_ARDUINO_NODE: is_version,
+    Presentation.S_ARDUINO_REPEATER_NODE: is_version,
+    Presentation.S_ARDUINO_RELAY: is_version})
 
 VALID_TYPES = {
     Presentation.S_DOOR: [SetReq.V_TRIPPED, SetReq.V_ARMED],
@@ -316,7 +322,7 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_PERCENTAGE: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        percent_int, vol.Coerce(str),
         msg='value must be between {} and {}'.format(0, 100)),
     SetReq.V_PRESSURE: str,
     SetReq.V_FORECAST: vol.Any(str, vol.In(
@@ -351,7 +357,7 @@ VALID_SETREQ = {
         msg='value must be one of: {}, {}, {} or {}'.format(
             MIN, NORMAL, MAX, AUTO)),
     SetReq.V_LIGHT_LEVEL: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
+        percent_int, vol.Coerce(str),
         msg='value must be between {} and {}'.format(0, 100)),
     SetReq.V_VAR1: str,
     SetReq.V_VAR2: str,

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from mysensors.const_15 import MAX_NODE_ID  # noqa: F401
 from mysensors.const_15 import (HANDLE_INTERNAL, VALID_INTERNAL, VALID_SETREQ,
                                 VALID_STREAM, VALID_TYPES)
+from mysensors.validation import is_version
 
 
 class MessageType(IntEnum):
@@ -44,6 +45,7 @@ class Presentation(IntEnum):
     S_LIGHT_LEVEL = 16              # Light sensor
     S_ARDUINO_NODE = 17             # Arduino node device
     S_ARDUINO_REPEATER_NODE = 18    # Arduino repeating node device
+    S_ARDUINO_RELAY = 18            # Alias for compatability
     S_LOCK = 19                     # Lock device
     S_IR = 20                       # Ir sender/receiver device
     S_WATER = 21                    # Water meter
@@ -270,6 +272,10 @@ VALID_MESSAGE_TYPES = {
 VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
+VALID_PRESENTATION.update({
+    Presentation.S_ARDUINO_NODE: is_version,
+    Presentation.S_ARDUINO_REPEATER_NODE: is_version,
+    Presentation.S_ARDUINO_RELAY: is_version})
 
 VALID_TYPES = dict(VALID_TYPES)
 VALID_TYPES.update({

--- a/mysensors/validation.py
+++ b/mysensors/validation.py
@@ -24,6 +24,17 @@ def is_version(value):
             '{} is not a valid version specifier'.format(value))
 
 
+def safe_is_version(value):
+    """Validate that value is a valid version string."""
+    try:
+        return is_version(value)
+    except vol.Invalid:
+        _LOGGER.warning(
+            '%s is not a valid version specifier, '
+            'falling back to version 1.4', value)
+        return '1.4'
+
+
 def is_battery_level(value):
     """Validate that value is a valid battery level integer."""
     try:

--- a/mysensors/validation.py
+++ b/mysensors/validation.py
@@ -1,0 +1,36 @@
+"""Expose validators to use in the library."""
+# pylint: disable=import-error, no-name-in-module
+from distutils.version import LooseVersion as parse_ver
+import logging
+
+import voluptuous as vol
+
+# pylint: disable=invalid-name
+
+_LOGGER = logging.getLogger(__name__)
+
+percent_int = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+
+
+def is_version(value):
+    """Validate that value is a valid version string."""
+    try:
+        value = str(value)
+        if not parse_ver('1.4') <= parse_ver(value):
+            raise ValueError()
+        return value
+    except (AttributeError, TypeError, ValueError):
+        raise vol.Invalid(
+            '{} is not a valid version specifier'.format(value))
+
+
+def is_battery_level(value):
+    """Validate that value is a valid battery level integer."""
+    try:
+        value = percent_int(value)
+        return value
+    except vol.Invalid:
+        _LOGGER.warning(
+            '%s is not a valid battery level, falling back to battery level 0',
+            value)
+        return 0

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,6 +1,9 @@
 """Test mysensors messages."""
 from unittest import TestCase
 
+import pytest
+import voluptuous as vol
+
 from mysensors import get_const, Message
 from mysensors.const_14 import Internal, MessageType
 
@@ -25,6 +28,23 @@ PRES_FIXTURES_20 = {
     'S_ARDUINO_RELAY': '2.0',
     'S_MOISTURE': 'Moisture Sensor',
     'S_WATER_QUALITY': 'Water Quality Sensor',
+}
+
+PRES_BAD_FIXTURES_14 = {
+    'S_ARDUINO_NODE': 'None',
+    'S_ARDUINO_RELAY': '-1',
+}
+
+PRES_BAD_FIXTURES_15 = {
+    'S_ARDUINO_NODE': 'None',
+    'S_ARDUINO_REPEATER_NODE': '1.3',
+    'S_ARDUINO_RELAY': '-1',
+}
+
+PRES_BAD_FIXTURES_20 = {
+    'S_ARDUINO_NODE': 'None',
+    'S_ARDUINO_REPEATER_NODE': '1.3',
+    'S_ARDUINO_RELAY': '-1',
 }
 
 SET_FIXTURES_14 = {
@@ -199,6 +219,20 @@ def test_validate_pres():
             assert valid == {
                 'node_id': 1, 'child_id': 0, 'type': 0, 'ack': 0,
                 'sub_type': sub_type, 'payload': payload}
+
+
+def test_validate_bad_pres():
+    """Test bad Presentation messages."""
+    versions = [
+        ('1.4', PRES_BAD_FIXTURES_14), ('1.5', PRES_BAD_FIXTURES_15),
+        ('2.0', PRES_BAD_FIXTURES_20)]
+    for protocol_version, fixture in versions:
+        const = get_const(protocol_version)
+        for name, payload in fixture.items():
+            sub_type = const.Presentation[name]
+            msg = Message('1;0;0;0;{};{}\n'.format(sub_type, payload))
+            with pytest.raises(vol.Invalid):
+                msg.validate(protocol_version)
 
 
 def test_validate_set():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -51,7 +51,7 @@ SET_FIXTURES_14 = {
     'V_SCENE_OFF': 'scene_4',
     'V_HEATER': 'AutoChangeOver',
     'V_HEATER_SW': '1',
-    'V_LIGHT_LEVEL': '99',
+    'V_LIGHT_LEVEL': '99.0',
     'V_VAR1': 'test1',
     'V_VAR2': 'test2',
     'V_VAR3': 'test3',

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -4,6 +4,29 @@ from unittest import TestCase
 from mysensors import get_const, Message
 from mysensors.const_14 import Internal, MessageType
 
+PRES_FIXTURES_14 = {
+    'S_DOOR': 'Front Door',
+    'S_ARDUINO_NODE': '1.4',
+    'S_ARDUINO_RELAY': '1.4',
+}
+
+PRES_FIXTURES_15 = {
+    'S_DOOR': 'Front Door',
+    'S_ARDUINO_NODE': '1.5',
+    'S_ARDUINO_REPEATER_NODE': '1.5',
+    'S_ARDUINO_RELAY': '1.5',
+    'S_MOISTURE': 'Moisture Sensor',
+}
+
+PRES_FIXTURES_20 = {
+    'S_DOOR': 'Front Door',
+    'S_ARDUINO_NODE': '2.0',
+    'S_ARDUINO_REPEATER_NODE': '2.0',
+    'S_ARDUINO_RELAY': '2.0',
+    'S_MOISTURE': 'Moisture Sensor',
+    'S_WATER_QUALITY': 'Water Quality Sensor',
+}
+
 SET_FIXTURES_14 = {
     'V_TEMP': '20.0',
     'V_HUM': '30',
@@ -160,6 +183,22 @@ class TestMessage(TestCase):
         """Test decode of bad message."""
         with self.assertRaises(ValueError):
             Message('bad;bad;bad;bad;bad;bad\n')
+
+
+def test_validate_pres():
+    """Test Presentation messages."""
+    versions = [
+        ('1.4', PRES_FIXTURES_14), ('1.5', PRES_FIXTURES_15),
+        ('2.0', PRES_FIXTURES_20)]
+    for protocol_version, fixture in versions:
+        const = get_const(protocol_version)
+        for name, payload in fixture.items():
+            sub_type = const.Presentation[name]
+            msg = Message('1;0;0;0;{};{}\n'.format(sub_type, payload))
+            valid = msg.validate(protocol_version)
+            assert valid == {
+                'node_id': 1, 'child_id': 0, 'type': 0, 'ack': 0,
+                'sub_type': sub_type, 'payload': payload}
 
 
 def test_validate_set():


### PR DESCRIPTION
After 0.11 there were reports of uncaught exceptions when persistence file contained null value for sensor protocol_version. This PR fixes the problem by adding validation of protocol_version and battery_level.

* Validate protocol_version and battery_level. If validation fails, log warning and fall back to safe default.
* Allow float for V_LIGHT_LEVEL in validation.
* Enhance some validation messages.
* Add alias from version 1.4 for S_ARDUINO_REPEATER_NODE in version 1.5 and 2.0.
* Add more tests.