### PR TITLE
0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Change Log
 
-## [0.11.0](https://github.com/theolind/pymysensors/tree/0.11.0) (2017-08-21)
-[Full Changelog](https://github.com/theolind/pymysensors/compare/0.10...0.11.0)
+## [0.11.1](https://github.com/theolind/pymysensors/tree/0.11.1) (2017-08-29)
+[Full Changelog](https://github.com/theolind/pymysensors/compare/0.11...0.11.1)
 
 **Merged pull requests:**
 
+- Fix protocol version null and enhance validation [\#108](https://github.com/theolind/pymysensors/pull/108) ([MartinHjelmare](https://github.com/MartinHjelmare))
+
+## [0.11](https://github.com/theolind/pymysensors/tree/0.11) (2017-08-21)
+[Full Changelog](https://github.com/theolind/pymysensors/compare/0.10...0.11)
+
+**Merged pull requests:**
+
+- 0.11 [\#106](https://github.com/theolind/pymysensors/pull/106) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Add debug timer logging if handle queue is slow [\#105](https://github.com/theolind/pymysensors/pull/105) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Update gen\_changelog and release procedure [\#104](https://github.com/theolind/pymysensors/pull/104) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Update type schema and add message tests [\#103](https://github.com/theolind/pymysensors/pull/103) ([MartinHjelmare](https://github.com/MartinHjelmare))

--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -3,6 +3,8 @@ from enum import IntEnum
 
 import voluptuous as vol
 
+from mysensors.validation import is_version, percent_int
+
 
 class MessageType(IntEnum):
     """MySensors message types."""
@@ -163,6 +165,9 @@ VALID_MESSAGE_TYPES = {
 VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
+VALID_PRESENTATION.update({
+    Presentation.S_ARDUINO_NODE: is_version,
+    Presentation.S_ARDUINO_RELAY: is_version})
 
 VALID_TYPES = {
     Presentation.S_DOOR: [SetReq.V_TRIPPED, SetReq.V_ARMED],
@@ -222,8 +227,8 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_DIMMER: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        percent_int, vol.Coerce(str),
+        msg='value must be integer between {} and {}'.format(0, 100)),
     SetReq.V_PRESSURE: str,
     SetReq.V_FORECAST: vol.Any(str, vol.In(
         FORECASTS,
@@ -256,8 +261,8 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_LIGHT_LEVEL: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        vol.Coerce(float), vol.Range(min=0.0, max=100.0), vol.Coerce(str),
+        msg='value must be float between {} and {}'.format(0.0, 100.0)),
     SetReq.V_VAR1: str,
     SetReq.V_VAR2: str,
     SetReq.V_VAR3: str,
@@ -284,7 +289,8 @@ MAX_NODE_ID = 254
 
 VALID_INTERNAL = {
     Internal.I_BATTERY_LEVEL: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str)),
+        percent_int, vol.Coerce(str),
+        msg='value must be integer between {} and {}'.format(0, 100)),
     Internal.I_TIME: vol.Any('', vol.All(vol.Coerce(int), vol.Coerce(str))),
     Internal.I_VERSION: str,
     Internal.I_ID_REQUEST: '',

--- a/mysensors/const_15.py
+++ b/mysensors/const_15.py
@@ -9,6 +9,7 @@ from mysensors.const_14 import HANDLE_INTERNAL, MAX_NODE_ID  # noqa: F401
 from mysensors.const_14 import (AUTO_CHANGE_OVER, COOL_ON, FORECASTS, HEAT_ON,
                                 LOGICAL_ONE, LOGICAL_ZERO, OFF, VALID_INTERNAL,
                                 VALID_STREAM)
+from mysensors.validation import is_version, percent_int
 
 
 class MessageType(IntEnum):
@@ -46,6 +47,7 @@ class Presentation(IntEnum):
     S_LIGHT_LEVEL = 16              # Light sensor
     S_ARDUINO_NODE = 17             # Arduino node device
     S_ARDUINO_REPEATER_NODE = 18    # Arduino repeating node device
+    S_ARDUINO_RELAY = 18            # Alias for compatability
     S_LOCK = 19                     # Lock device
     S_IR = 20                       # Ir sender/receiver device
     S_WATER = 21                    # Water meter
@@ -210,6 +212,10 @@ VALID_MESSAGE_TYPES = {
 VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
+VALID_PRESENTATION.update({
+    Presentation.S_ARDUINO_NODE: is_version,
+    Presentation.S_ARDUINO_REPEATER_NODE: is_version,
+    Presentation.S_ARDUINO_RELAY: is_version})
 
 VALID_TYPES = {
     Presentation.S_DOOR: [SetReq.V_TRIPPED, SetReq.V_ARMED],
@@ -316,8 +322,8 @@ VALID_SETREQ = {
         [LOGICAL_ZERO, LOGICAL_ONE],
         msg='value must be either {} or {}'.format(LOGICAL_ZERO, LOGICAL_ONE)),
     SetReq.V_PERCENTAGE: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        percent_int, vol.Coerce(str),
+        msg='value must be integer between {} and {}'.format(0, 100)),
     SetReq.V_PRESSURE: str,
     SetReq.V_FORECAST: vol.Any(str, vol.In(
         FORECASTS,
@@ -351,8 +357,8 @@ VALID_SETREQ = {
         msg='value must be one of: {}, {}, {} or {}'.format(
             MIN, NORMAL, MAX, AUTO)),
     SetReq.V_LIGHT_LEVEL: vol.All(
-        vol.Coerce(int), vol.Range(min=0, max=100), vol.Coerce(str),
-        msg='value must be between {} and {}'.format(0, 100)),
+        vol.Coerce(float), vol.Range(min=0.0, max=100.0), vol.Coerce(str),
+        msg='value must be float between {} and {}'.format(0.0, 100.0)),
     SetReq.V_VAR1: str,
     SetReq.V_VAR2: str,
     SetReq.V_VAR3: str,

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from mysensors.const_15 import MAX_NODE_ID  # noqa: F401
 from mysensors.const_15 import (HANDLE_INTERNAL, VALID_INTERNAL, VALID_SETREQ,
                                 VALID_STREAM, VALID_TYPES)
+from mysensors.validation import is_version
 
 
 class MessageType(IntEnum):
@@ -44,6 +45,7 @@ class Presentation(IntEnum):
     S_LIGHT_LEVEL = 16              # Light sensor
     S_ARDUINO_NODE = 17             # Arduino node device
     S_ARDUINO_REPEATER_NODE = 18    # Arduino repeating node device
+    S_ARDUINO_RELAY = 18            # Alias for compatability
     S_LOCK = 19                     # Lock device
     S_IR = 20                       # Ir sender/receiver device
     S_WATER = 21                    # Water meter
@@ -270,6 +272,10 @@ VALID_MESSAGE_TYPES = {
 VALID_PRESENTATION = {
     member: str for member in list(Presentation)
 }
+VALID_PRESENTATION.update({
+    Presentation.S_ARDUINO_NODE: is_version,
+    Presentation.S_ARDUINO_REPEATER_NODE: is_version,
+    Presentation.S_ARDUINO_RELAY: is_version})
 
 VALID_TYPES = dict(VALID_TYPES)
 VALID_TYPES.update({

--- a/mysensors/validation.py
+++ b/mysensors/validation.py
@@ -1,0 +1,47 @@
+"""Expose validators to use in the library."""
+# pylint: disable=import-error, no-name-in-module
+from distutils.version import LooseVersion as parse_ver
+import logging
+
+import voluptuous as vol
+
+# pylint: disable=invalid-name
+
+_LOGGER = logging.getLogger(__name__)
+
+percent_int = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+
+
+def is_version(value):
+    """Validate that value is a valid version string."""
+    try:
+        value = str(value)
+        if not parse_ver('1.4') <= parse_ver(value):
+            raise ValueError()
+        return value
+    except (AttributeError, TypeError, ValueError):
+        raise vol.Invalid(
+            '{} is not a valid version specifier'.format(value))
+
+
+def safe_is_version(value):
+    """Validate that value is a valid version string."""
+    try:
+        return is_version(value)
+    except vol.Invalid:
+        _LOGGER.warning(
+            '%s is not a valid version specifier, '
+            'falling back to version 1.4', value)
+        return '1.4'
+
+
+def is_battery_level(value):
+    """Validate that value is a valid battery level integer."""
+    try:
+        value = percent_int(value)
+        return value
+    except vol.Invalid:
+        _LOGGER.warning(
+            '%s is not a valid battery level, falling back to battery level 0',
+            value)
+        return 0

--- a/mysensors/version.py
+++ b/mysensors/version.py
@@ -1,5 +1,5 @@
 """Store version constants."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
-PATCH_VERSION = 0
+PATCH_VERSION = 1
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,8 +1,51 @@
 """Test mysensors messages."""
 from unittest import TestCase
 
+import pytest
+import voluptuous as vol
+
 from mysensors import get_const, Message
 from mysensors.const_14 import Internal, MessageType
+
+PRES_FIXTURES_14 = {
+    'S_DOOR': 'Front Door',
+    'S_ARDUINO_NODE': '1.4',
+    'S_ARDUINO_RELAY': '1.4',
+}
+
+PRES_FIXTURES_15 = {
+    'S_DOOR': 'Front Door',
+    'S_ARDUINO_NODE': '1.5',
+    'S_ARDUINO_REPEATER_NODE': '1.5',
+    'S_ARDUINO_RELAY': '1.5',
+    'S_MOISTURE': 'Moisture Sensor',
+}
+
+PRES_FIXTURES_20 = {
+    'S_DOOR': 'Front Door',
+    'S_ARDUINO_NODE': '2.0',
+    'S_ARDUINO_REPEATER_NODE': '2.0',
+    'S_ARDUINO_RELAY': '2.0',
+    'S_MOISTURE': 'Moisture Sensor',
+    'S_WATER_QUALITY': 'Water Quality Sensor',
+}
+
+PRES_BAD_FIXTURES_14 = {
+    'S_ARDUINO_NODE': 'None',
+    'S_ARDUINO_RELAY': '-1',
+}
+
+PRES_BAD_FIXTURES_15 = {
+    'S_ARDUINO_NODE': 'None',
+    'S_ARDUINO_REPEATER_NODE': '1.3',
+    'S_ARDUINO_RELAY': '-1',
+}
+
+PRES_BAD_FIXTURES_20 = {
+    'S_ARDUINO_NODE': 'None',
+    'S_ARDUINO_REPEATER_NODE': '1.3',
+    'S_ARDUINO_RELAY': '-1',
+}
 
 SET_FIXTURES_14 = {
     'V_TEMP': '20.0',
@@ -28,7 +71,7 @@ SET_FIXTURES_14 = {
     'V_SCENE_OFF': 'scene_4',
     'V_HEATER': 'AutoChangeOver',
     'V_HEATER_SW': '1',
-    'V_LIGHT_LEVEL': '99',
+    'V_LIGHT_LEVEL': '99.0',
     'V_VAR1': 'test1',
     'V_VAR2': 'test2',
     'V_VAR3': 'test3',
@@ -160,6 +203,36 @@ class TestMessage(TestCase):
         """Test decode of bad message."""
         with self.assertRaises(ValueError):
             Message('bad;bad;bad;bad;bad;bad\n')
+
+
+def test_validate_pres():
+    """Test Presentation messages."""
+    versions = [
+        ('1.4', PRES_FIXTURES_14), ('1.5', PRES_FIXTURES_15),
+        ('2.0', PRES_FIXTURES_20)]
+    for protocol_version, fixture in versions:
+        const = get_const(protocol_version)
+        for name, payload in fixture.items():
+            sub_type = const.Presentation[name]
+            msg = Message('1;0;0;0;{};{}\n'.format(sub_type, payload))
+            valid = msg.validate(protocol_version)
+            assert valid == {
+                'node_id': 1, 'child_id': 0, 'type': 0, 'ack': 0,
+                'sub_type': sub_type, 'payload': payload}
+
+
+def test_validate_bad_pres():
+    """Test bad Presentation messages."""
+    versions = [
+        ('1.4', PRES_BAD_FIXTURES_14), ('1.5', PRES_BAD_FIXTURES_15),
+        ('2.0', PRES_BAD_FIXTURES_20)]
+    for protocol_version, fixture in versions:
+        const = get_const(protocol_version)
+        for name, payload in fixture.items():
+            sub_type = const.Presentation[name]
+            msg = Message('1;0;0;0;{};{}\n'.format(sub_type, payload))
+            with pytest.raises(vol.Invalid):
+                msg.validate(protocol_version)
 
 
 def test_validate_set():


### PR DESCRIPTION
If you have a persistence file containing `protocol_version` with value `null` the library will fallback to version `'1.4'`: Please update the value to the correct protocol version string of your sensor, or delete the persistence file and make sure your devices present themselves properly again. See #108 for more info.

**Merged pull requests:**

- Fix protocol version null and enhance validation [\#108](https://github.com/theolind/pymysensors/pull/108) ([MartinHjelmare](https://github.com/MartinHjelmare))