### PR TITLE
Fix reboot not returning to False

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -74,10 +74,11 @@ class Gateway(object):
             # this is a presentation of the sensor platform
             sensorid = self.add_sensor(msg.node_id)
             if sensorid is None:
+                if msg.node_id in self.sensors:
+                    self.sensors[msg.node_id].reboot = False
                 return
             self.sensors[msg.node_id].type = msg.sub_type
             self.sensors[msg.node_id].protocol_version = msg.payload
-            self.sensors[msg.node_id].reboot = False
             self.alert(msg)
             return msg
         else:

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -466,6 +466,8 @@ class TestGateway(TestCase):
         sensor.reboot = True
         ret = self.gateway.logic('1;0;1;0;23;43\n')
         self.assertEqual(ret, '1;255;3;0;13;\n')
+        self.gateway.logic('1;255;0;0;17;1.4.1\n')
+        self.assertEqual(sensor.reboot, False)
 
     def test_set_child_value(self):
         """Test Gateway method set_child_value."""


### PR DESCRIPTION
* Node attribute reboot should be set to False after node presentation message has been received for an existing node.