### PR TITLE
Add a few INTERNAL sub-types that were added in 2.2.0\n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Change Log
 
-## [0.12.0](https://github.com/theolind/pymysensors/tree/0.12.0) (2018-01-14)
-[Full Changelog](https://github.com/theolind/pymysensors/compare/0.11.1...0.12.0)
+## [0.12.1](https://github.com/theolind/pymysensors/tree/0.12.1) (2018-01-15)
+[Full Changelog](https://github.com/theolind/pymysensors/compare/0.12...0.12.1)
+
+**Closed issues:**
+
+- python 2.7 [\#83](https://github.com/theolind/pymysensors/issues/83)
+
+**Merged pull requests:**
+
+- Fix bug in \_handle\_internal [\#116](https://github.com/theolind/pymysensors/pull/116) ([MartinHjelmare](https://github.com/MartinHjelmare))
+
+## [0.12](https://github.com/theolind/pymysensors/tree/0.12) (2018-01-14)
+[Full Changelog](https://github.com/theolind/pymysensors/compare/0.11.1...0.12)
 
 **Closed issues:**
 
@@ -9,6 +20,7 @@
 
 **Merged pull requests:**
 
+- 0.12 [\#115](https://github.com/theolind/pymysensors/pull/115) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Upgrade lint and test requirements [\#114](https://github.com/theolind/pymysensors/pull/114) ([MartinHjelmare](https://github.com/MartinHjelmare))
 - Dump JSON file with indentation [\#113](https://github.com/theolind/pymysensors/pull/113) ([Mirodin](https://github.com/Mirodin))
 - Fix reboot not returning to False [\#111](https://github.com/theolind/pymysensors/pull/111) ([MartinHjelmare](https://github.com/MartinHjelmare))

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -246,6 +246,11 @@ class Internal(IntEnum):
     I_REGISTRATION_REQUEST = 26  # Register request to GW
     I_REGISTRATION_RESPONSE = 27  # Register response from GW
     I_DEBUG = 28  # Debug message
+    I_SIGNAL_REPORT_REQUEST = 29  # Device signal strength request
+    I_SIGNAL_REPORT_REVERSE = 30  # Internal
+    I_SIGNAL_REPORT_RESPONSE = 31  # Device signal strength response (RSSI)
+    I_PRE_SLEEP_NOTIFICATION = 32  # Message sent before node is going to sleep
+    I_POST_SLEEP_NOTIFICATION = 33  # Message sent after node woke up (if enabled)
 
 
 class Stream(IntEnum):


### PR DESCRIPTION
In 2.2.0 a few internal sub-types were added to the messages, which aren't listed on the website, but are used by the NodeManager library.  They are notifications that the node is going to sleep waking, and sending signal strength.  These cause warnings to be shown in homeassistant, and maybe other controllers.

I added these to const_20.py.  You may prefer to start a const_22.py.
  