### PR TITLE
Save sensors on a schedule

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -249,19 +249,18 @@ class Gateway(object):
         fname = os.path.realpath(self.persistence_file)
         exists = os.path.isfile(fname)
         dirname = os.path.dirname(fname)
-        if exists and os.access(fname, os.W_OK) and \
-           os.access(dirname, os.W_OK) or \
-           not exists and os.access(dirname, os.W_OK):
-            split_fname = os.path.splitext(fname)
-            tmp_fname = '{}.tmp{}'.format(split_fname[0], split_fname[1])
-            self._perform_file_action(tmp_fname, 'save')
-            if exists:
-                os.rename(fname, self.persistence_bak)
-            os.rename(tmp_fname, fname)
-            if exists:
-                os.remove(self.persistence_bak)
-        else:
+        if (not os.access(dirname, os.W_OK) or exists and
+                not os.access(fname, os.W_OK)):
             _LOGGER.error('Permission denied when writing to %s', fname)
+            return
+        split_fname = os.path.splitext(fname)
+        tmp_fname = '{}.tmp{}'.format(split_fname[0], split_fname[1])
+        self._perform_file_action(tmp_fname, 'save')
+        if exists:
+            os.rename(fname, self.persistence_bak)
+        os.rename(tmp_fname, fname)
+        if exists:
+            os.remove(self.persistence_bak)
 
     def _load_sensors(self, path=None):
         """Load sensors from file."""

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -152,10 +152,13 @@ class MQTTGateway(Gateway, threading.Thread):
         """Stop the background thread."""
         _LOGGER.info('Stopping thread')
         self._stop_event.set()
+        if self.scheduled_save is not None:
+            self.scheduled_save.cancel()
 
     def run(self):
         """Background thread that sends messages to the gateway via MQTT."""
         self._init_topics()
+        self._schedule_save_sensors()
         while not self._stop_event.is_set():
             response = self.handle_queue()
             if response is not None:
@@ -163,3 +166,4 @@ class MQTTGateway(Gateway, threading.Thread):
             if not self.queue.empty():
                 continue
             time.sleep(0.02)  # short sleep to avoid burning 100% cpu
+        self._save_sensors()

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -166,4 +166,5 @@ class MQTTGateway(Gateway, threading.Thread):
             if not self.queue.empty():
                 continue
             time.sleep(0.02)  # short sleep to avoid burning 100% cpu
-        self._save_sensors()
+        if self.persistence:
+            self._save_sensors()

--- a/mysensors/gateway_serial.py
+++ b/mysensors/gateway_serial.py
@@ -102,7 +102,8 @@ class SerialGateway(Gateway, threading.Thread):
                 continue
             self.fill_queue(self.logic, (string,))
         self.disconnect()  # Disconnect after stop event is set
-        self._save_sensors()
+        if self.persistence:
+            self._save_sensors()
 
     def send(self, message):
         """Write a Message to the gateway."""

--- a/mysensors/gateway_serial.py
+++ b/mysensors/gateway_serial.py
@@ -50,6 +50,7 @@ class SerialGateway(Gateway, threading.Thread):
         except serial.SerialException:
             _LOGGER.error('Unable to connect to %s', self.port)
             return False
+        self._schedule_save_sensors()
         return True
 
     def disconnect(self):
@@ -65,6 +66,8 @@ class SerialGateway(Gateway, threading.Thread):
         """Stop the background thread."""
         _LOGGER.info('Stopping thread')
         self._stop_event.set()
+        if self.scheduled_save is not None:
+            self.scheduled_save.cancel()
 
     def run(self):
         """Background thread that reads messages from the gateway."""
@@ -99,6 +102,7 @@ class SerialGateway(Gateway, threading.Thread):
                 continue
             self.fill_queue(self.logic, (string,))
         self.disconnect()  # Disconnect after stop event is set
+        self._save_sensors()
 
     def send(self, message):
         """Write a Message to the gateway."""

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -195,4 +195,5 @@ class TCPGateway(Gateway, threading.Thread):
                     self.fill_queue(self.logic, (line,))
             self._check_connection()
         self.disconnect()
-        self._save_sensors()
+        if self.persistence:
+            self._save_sensors()

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -65,6 +65,7 @@ class TCPGateway(Gateway, threading.Thread):
             self.sock = socket.create_connection(
                 self.server_address, self.reconnect_timeout)
             _LOGGER.info('Connected to %s', self.server_address)
+            self._schedule_save_sensors()
             return True
 
         except TimeoutError:
@@ -94,6 +95,8 @@ class TCPGateway(Gateway, threading.Thread):
         """Stop the background thread."""
         _LOGGER.info('Stopping thread')
         self._stop_event.set()
+        if self.scheduled_save is not None:
+            self.scheduled_save.cancel()
 
     def _check_socket(self, sock=None, timeout=None):
         """Check if socket is readable/writable."""
@@ -192,3 +195,4 @@ class TCPGateway(Gateway, threading.Thread):
                     self.fill_queue(self.logic, (line,))
             self._check_connection()
         self.disconnect()
+        self._save_sensors()

--- a/tests/test_gateway_mqtt.py
+++ b/tests/test_gateway_mqtt.py
@@ -105,9 +105,11 @@ class TestMQTTGateway(TestCase):
             'ERROR:mysensors.gateway_mqtt:Subscribe to /1/1/1/+/+ failed: '
             'No topic specified, or incorrect topic type.')
 
+    @mock.patch('mysensors.Gateway._save_sensors')
     @mock.patch('mysensors.Gateway._schedule_save_sensors')
-    def test_start_stop_gateway(self, mock_schedule_save):
+    def test_start_stop_gateway(self, mock_schedule_save, mock_save):
         """Test start and stop of MQTT gateway."""
+        self.gateway.persistence = True
         self.gateway.scheduled_save = mock.MagicMock()
         self.assertFalse(self.gateway.is_alive())
         sensor = self._add_sensor(1)
@@ -133,6 +135,7 @@ class TestMQTTGateway(TestCase):
         self.gateway.join(timeout=0.5)
         self.assertFalse(self.gateway.is_alive())
         assert self.gateway.scheduled_save.cancel.call_count == 1
+        assert mock_save.call_count == 1
 
     def test_mqtt_load_persistence(self):
         """Test load persistence file for MQTTGateway."""

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -421,11 +421,9 @@ class TestGateway(TestCase):
     def _callback(self, message):
         self.gateway.test_callback_message = message
 
-    @mock.patch('mysensors.mysensors.Gateway._save_sensors')
-    def test_callback(self, mock_save_sensors):
+    def test_callback(self):
         """Test gateway callback function."""
         self.gateway.event_callback = self._callback
-        self.gateway.persistence = True
         self.gateway.test_callback_message = None
         sensor = self._add_sensor(1)
         sensor.children[0] = ChildSensor(
@@ -440,7 +438,6 @@ class TestGateway(TestCase):
         self.assertEqual(0, self.gateway.test_callback_message.ack)
         self.assertEqual(23, self.gateway.test_callback_message.sub_type)
         self.assertEqual('43', self.gateway.test_callback_message.payload)
-        assert mock_save_sensors.called
 
     def test_callback_exception(self):
         """Test gateway callback with exception."""


### PR DESCRIPTION
* Saving sensors to a persistence file does I/O, which is expensive. So instead of doing this after every sensor update, which can be very frequent, save the sensors on a schedule every 10 seconds.
* Make sure we cancel the schedule when stopping the gateway and that we save the sensors before exiting.