### PR TITLE
Refactor persistence

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -23,17 +23,19 @@ _LOGGER = logging.getLogger(__name__)
 class Gateway(object):
     """Base implementation for a MySensors Gateway."""
 
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes, too-many-arguments
 
     def __init__(self, event_callback=None, persistence=False,
-                 persistence_file='mysensors.pickle', protocol_version='1.4'):
+                 persistence_file='mysensors.pickle', protocol_version='1.4',
+                 persistence_scheduler=None):
         """Set up Gateway."""
         self.queue = Queue()
         self.event_callback = event_callback
         self.sensors = {}
         self.metric = True  # if true - use metric, if false - use imperial
         if persistence:
-            self.persistence = Persistence(self.sensors, persistence_file)
+            self.persistence = Persistence(
+                self.sensors, persistence_file, persistence_scheduler)
         else:
             self.persistence = None
         self.protocol_version = safe_is_version(protocol_version)

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -1,49 +1,22 @@
 """Python implementation of MySensors API."""
 import calendar
-import json
 import logging
-import os
-import pickle
-import threading
 import time
-from collections import deque
-# pylint: disable=import-error, no-name-in-module
 from distutils.version import LooseVersion as parse_ver
-from importlib import import_module
 from queue import Queue
 from timeit import default_timer as timer
 
 import voluptuous as vol
 
-from .validation import is_battery_level, safe_is_version
+from .const import get_const
+from .message import Message, SYSTEM_CHILD_ID
 from .ota import OTAFirmware
+from .persistence import Persistence
+from .sensor import ChildSensor, Sensor
+from .validation import safe_is_version
 from .version import __version__  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
-
-BROADCAST_ID = 255
-LOADED_CONST = {}
-SYSTEM_CHILD_ID = 255
-
-
-def get_const(protocol_version):
-    """Return the const module for the protocol_version."""
-    version = protocol_version
-    if parse_ver('1.5') <= parse_ver(version) < parse_ver('2.0'):
-        path = 'mysensors.const_15'
-    elif parse_ver(version) >= parse_ver('2.2'):
-        path = 'mysensors.const_22'
-    elif parse_ver(version) >= parse_ver('2.1'):
-        path = 'mysensors.const_21'
-    elif parse_ver(version) >= parse_ver('2.0'):
-        path = 'mysensors.const_20'
-    else:
-        path = 'mysensors.const_14'
-    if path in LOADED_CONST:
-        return LOADED_CONST[path]
-    const = import_module(path)
-    LOADED_CONST[path] = const  # Cache the module
-    return const
 
 
 class Gateway(object):
@@ -55,19 +28,18 @@ class Gateway(object):
                  persistence_file='mysensors.pickle', protocol_version='1.4'):
         """Set up Gateway."""
         self.queue = Queue()
-        self.lock = threading.Lock()
         self.event_callback = event_callback
         self.sensors = {}
         self.metric = True  # if true - use metric, if false - use imperial
-        self.persistence = persistence  # if true - save sensors to disk
-        self.persistence_file = persistence_file  # path to persistence file
-        self.persistence_bak = '{}.bak'.format(self.persistence_file)
-        self.scheduled_save = None
+        if persistence:
+            self.persistence = Persistence(self.sensors, persistence_file)
+        else:
+            self.persistence = None
         self.protocol_version = safe_is_version(protocol_version)
         self.const = get_const(self.protocol_version)
         self.ota = OTAFirmware(self.sensors, self.const)
         if persistence:
-            self._safe_load_sensors()
+            self.persistence.safe_load_sensors()
 
     def __repr__(self):
         """Return the representation."""
@@ -219,107 +191,6 @@ class Gateway(object):
         ret = ret.encode() if ret else None
         return ret
 
-    def _save_pickle(self, filename):
-        """Save sensors to pickle file."""
-        with open(filename, 'wb') as file_handle:
-            pickle.dump(self.sensors, file_handle, pickle.HIGHEST_PROTOCOL)
-            file_handle.flush()
-            os.fsync(file_handle.fileno())
-
-    def _load_pickle(self, filename):
-        """Load sensors from pickle file."""
-        with open(filename, 'rb') as file_handle:
-            self.sensors.update(pickle.load(file_handle))
-
-    def _save_json(self, filename):
-        """Save sensors to json file."""
-        with open(filename, 'w') as file_handle:
-            json.dump(self.sensors, file_handle, cls=MySensorsJSONEncoder,
-                      indent=4)
-            file_handle.flush()
-            os.fsync(file_handle.fileno())
-
-    def _load_json(self, filename):
-        """Load sensors from json file."""
-        with open(filename, 'r') as file_handle:
-            self.sensors.update(json.load(
-                file_handle, cls=MySensorsJSONDecoder))
-
-    def _save_sensors(self):
-        """Save sensors to file."""
-        fname = os.path.realpath(self.persistence_file)
-        exists = os.path.isfile(fname)
-        dirname = os.path.dirname(fname)
-        if (not os.access(dirname, os.W_OK) or exists and
-                not os.access(fname, os.W_OK)):
-            _LOGGER.error('Permission denied when writing to %s', fname)
-            return
-        split_fname = os.path.splitext(fname)
-        tmp_fname = '{}.tmp{}'.format(split_fname[0], split_fname[1])
-        self._perform_file_action(tmp_fname, 'save')
-        if exists:
-            os.rename(fname, self.persistence_bak)
-        os.rename(tmp_fname, fname)
-        if exists:
-            os.remove(self.persistence_bak)
-
-    def _schedule_save_sensors(self):
-        """Schedule a call to save sensors every 10 seconds.
-
-        Call this method once when the connection is established.
-        """
-        if not self.persistence:
-            return
-        self._save_sensors()
-        self.scheduled_save = threading.Timer(
-            10.0, self._schedule_save_sensors)
-        self.scheduled_save.start()
-
-    def _load_sensors(self, path=None):
-        """Load sensors from file."""
-        if path is None:
-            path = self.persistence_file
-        exists = os.path.isfile(path)
-        if exists and os.access(path, os.R_OK):
-            if path == self.persistence_bak:
-                os.rename(path, self.persistence_file)
-                path = self.persistence_file
-            self._perform_file_action(path, 'load')
-            return True
-        else:
-            _LOGGER.warning('File does not exist or is not readable: %s', path)
-            return False
-
-    def _safe_load_sensors(self):
-        """Load sensors safely from file."""
-        try:
-            loaded = self._load_sensors()
-        except (EOFError, ValueError):
-            _LOGGER.error('Bad file contents: %s', self.persistence_file)
-            loaded = False
-        if not loaded:
-            _LOGGER.warning('Trying backup file: %s', self.persistence_bak)
-            try:
-                if not self._load_sensors(self.persistence_bak):
-                    _LOGGER.warning('Failed to load sensors from file: %s',
-                                    self.persistence_file)
-            except (EOFError, ValueError):
-                _LOGGER.error('Bad file contents: %s', self.persistence_file)
-                _LOGGER.warning('Removing file: %s', self.persistence_file)
-                os.remove(self.persistence_file)
-
-    def _perform_file_action(self, filename, action):
-        """Perform action on specific file types.
-
-        Dynamic dispatch function for performing actions on
-        specific file types.
-        """
-        ext = os.path.splitext(filename)[1]
-        func = getattr(self, '_%s_%s' % (action, ext[1:]), None)
-        if func is None:
-            raise Exception('Unsupported file type %s' % ext[1:])
-        func(filename)
-
     def alert(self, msg):
         """Tell anyone who wants to know that a sensor was updated.
 
@@ -440,310 +311,3 @@ class Gateway(object):
     def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
         """Update firwmare of all node_ids in nids."""
         self.ota.make_update(nids, fw_type, fw_ver, fw_path)
-
-
-class Sensor(object):
-    """Represent a sensor."""
-
-    # pylint: disable=too-many-instance-attributes
-
-    def __init__(self, sensor_id):
-        """Set up sensor."""
-        self.sensor_id = sensor_id
-        self.children = {}
-        self.type = None
-        self.sketch_name = None
-        self.sketch_version = None
-        self._battery_level = 0
-        self._protocol_version = '1.4'
-        self.new_state = {}
-        self.queue = deque()
-        self.reboot = False
-
-    def __getstate__(self):
-        """Get state to save as pickle."""
-        state = self.__dict__.copy()
-        for attr in ('_battery_level', '_protocol_version'):
-            value = state.pop(attr, None)
-            prop = attr
-            if prop.startswith('_'):
-                prop = prop[1:]
-            if value is not None:
-                state[prop] = value
-
-        return state
-
-    def __setstate__(self, state):
-        """Set state when loading pickle."""
-        # Restore instance attributes
-        for key, val in state.items():
-            setattr(self, key, val)
-        # Reset some attributes
-        self.new_state = {}
-        self.queue = deque()
-        self.reboot = False
-
-    def __repr__(self):
-        """Return the representation."""
-        return '<Sensor sensor_id={}, children: {}>'.format(
-            self.sensor_id, self.children)
-
-    @property
-    def battery_level(self):
-        """Return battery level."""
-        return self._battery_level
-
-    @battery_level.setter
-    def battery_level(self, value):
-        """Set valid battery level."""
-        self._battery_level = is_battery_level(value)
-
-    @property
-    def protocol_version(self):
-        """Return protocol version."""
-        return self._protocol_version
-
-    @protocol_version.setter
-    def protocol_version(self, value):
-        """Set valid protocol version."""
-        self._protocol_version = safe_is_version(value)
-
-    def add_child_sensor(self, child_id, child_type, description=''):
-        """Create and add a child sensor."""
-        if child_id in self.children:
-            _LOGGER.warning(
-                'child_id %s already exists in children of node %s, '
-                'cannot add child', child_id, self.sensor_id)
-            return None
-        self.children[child_id] = ChildSensor(
-            child_id, child_type, description)
-        return child_id
-
-    def set_child_value(self, child_id, value_type, value, **kwargs):
-        """Set a child sensor's value."""
-        children = kwargs.get('children', self.children)
-        if not isinstance(children, dict) or child_id not in children:
-            return None
-        msg_type = kwargs.get('msg_type', 1)
-        ack = kwargs.get('ack', 0)
-        msg = Message().modify(
-            node_id=self.sensor_id, child_id=child_id, type=msg_type, ack=ack,
-            sub_type=value_type, payload=value)
-        msg_string = msg.encode()
-        if msg_string is None:
-            _LOGGER.error(
-                'Not a valid message: node %s, child %s, type %s, ack %s, '
-                'sub_type %s, payload %s',
-                self.sensor_id, child_id, msg_type, ack, value_type, value)
-            return None
-        try:
-            msg = Message(msg_string)
-            msg.validate(self.protocol_version)
-        except (ValueError, AttributeError, vol.Invalid) as exc:
-            _LOGGER.error('Not a valid message: %s', exc)
-            return None
-        child = children[msg.child_id]
-        child.values[msg.sub_type] = msg.payload
-        return msg_string
-
-
-class ChildSensor(object):
-    """Represent a child sensor."""
-
-    # pylint: disable=too-few-public-methods
-
-    def __init__(self, child_id, child_type, description=''):
-        """Set up child sensor."""
-        # pylint: disable=invalid-name
-        self.id = child_id
-        self.type = child_type
-        self.description = description
-        self.values = {}
-
-    def __setstate__(self, state):
-        """Set state when loading pickle."""
-        # Restore instance attributes
-        self.__dict__.update(state)
-        # Make sure all attributes exist
-        if 'description' not in self.__dict__:
-            self.description = ''
-
-    def __repr__(self):
-        """Return the representation."""
-        ret = ('<ChildSensor child_id={0!s}, child_type={1!s}, '
-               'description={2!s}, values: {3!s}>')
-        return ret.format(self.id, self.type, self.description, self.values)
-
-    def get_schema(self, protocol_version):
-        """Return the child schema for the correct const version."""
-        const = get_const(protocol_version)
-        return vol.Schema({
-            typ.value: const.VALID_SETREQ[typ]
-            for typ in const.VALID_TYPES[self.type]})
-
-    def validate(self, protocol_version, values=None):
-        """Validate child value types and values against protocol_version."""
-        if values is None:
-            values = self.values
-        return self.get_schema(protocol_version)(values)
-
-
-class Message(object):
-    """Represent a message from the gateway."""
-
-    def __init__(self, data=None, gateway=None):
-        """Set up message."""
-        self.node_id = 0
-        self.child_id = 0
-        self.type = 0
-        self.ack = 0
-        self.sub_type = 0
-        self.payload = ''  # All data except payload are integers
-        self.gateway = gateway
-        if data is not None:
-            self.decode(data)
-
-    def __repr__(self):
-        """Return the representation."""
-        return '<Message data="{};{};{};{};{};{}">'.format(
-            self.node_id, self.child_id, self.type, self.ack, self.sub_type,
-            self.payload)
-
-    def copy(self, **kwargs):
-        """Copy a message, optionally replace attributes with kwargs."""
-        msg = Message(self.encode(), self.gateway)
-        for key, val in kwargs.items():
-            setattr(msg, key, val)
-        return msg
-
-    def modify(self, **kwargs):
-        """Modify and return message, replace attributes with kwargs."""
-        for key, val in kwargs.items():
-            setattr(self, key, val)
-        return self
-
-    def decode(self, data, delimiter=';'):
-        """Decode a message from command string."""
-        try:
-            list_data = data.rstrip().split(delimiter)
-            self.payload = list_data.pop()
-            (self.node_id,
-             self.child_id,
-             self.type,
-             self.ack,
-             self.sub_type) = [int(f) for f in list_data]
-        except ValueError:
-            _LOGGER.warning('Error decoding message from gateway, '
-                            'bad data received: %s', data)
-            raise ValueError
-
-    def encode(self, delimiter=';'):
-        """Encode a command string from message."""
-        try:
-            return delimiter.join([str(f) for f in [
-                self.node_id,
-                self.child_id,
-                int(self.type),
-                self.ack,
-                int(self.sub_type),
-                self.payload,
-            ]]) + '\n'
-        except ValueError:
-            _LOGGER.error('Error encoding message to gateway')
-
-    def validate(self, protocol_version):
-        """Validate message."""
-        const = get_const(protocol_version)
-        valid_node_ids = vol.All(vol.Coerce(int), vol.Range(
-            min=0, max=BROADCAST_ID, msg='Not valid node_id: {}'.format(
-                self.node_id)))
-        valid_child_ids = vol.All(vol.Coerce(int), vol.Range(
-            min=0, max=SYSTEM_CHILD_ID, msg='Not valid child_id: {}'.format(
-                self.child_id)))
-        if self.type in (const.MessageType.internal, const.MessageType.stream):
-            valid_child_ids = vol.All(vol.Coerce(int), vol.In(
-                [SYSTEM_CHILD_ID],
-                msg='When message type is {}, child_id must be {}'.format(
-                    self.type, SYSTEM_CHILD_ID)))
-        if (self.type == const.MessageType.internal and
-                self.sub_type in [
-                    const.Internal.I_ID_REQUEST,
-                    const.Internal.I_ID_RESPONSE]):
-            valid_child_ids = vol.Coerce(int)
-        valid_types = vol.All(vol.Coerce(int), vol.In(
-            [member.value for member in const.VALID_MESSAGE_TYPES],
-            msg='Not valid message type: {}'.format(self.type)))
-        if self.child_id == SYSTEM_CHILD_ID:
-            valid_types = vol.All(vol.Coerce(int), vol.In(
-                [const.MessageType.presentation.value,
-                 const.MessageType.internal.value,
-                 const.MessageType.stream.value],
-                msg=(
-                    'When child_id is {}, {} is not a valid '
-                    'message type'.format(SYSTEM_CHILD_ID, self.type))))
-        valid_ack = vol.In([0, 1], msg='Not valid ack flag: {}'.format(
-            self.ack))
-        valid_sub_types = vol.In(
-            [member.value for member
-             in const.VALID_MESSAGE_TYPES.get(self.type, [])],
-            msg='Not valid message sub-type: {}'.format(self.sub_type))
-        valid_payload = const.VALID_PAYLOADS.get(
-            self.type, {}).get(self.sub_type, '')
-        schema = vol.Schema({
-            'node_id': valid_node_ids, 'child_id': valid_child_ids,
-            'type': valid_types, 'ack': valid_ack, 'sub_type': valid_sub_types,
-            'payload': valid_payload})
-        to_validate = {attr: getattr(self, attr) for attr in schema.schema}
-        return schema(to_validate)
-
-
-class MySensorsJSONEncoder(json.JSONEncoder):
-    """JSON encoder."""
-
-    def default(self, obj):
-        """Serialize obj into JSON."""
-        # pylint: disable=method-hidden, protected-access, arguments-differ
-        if isinstance(obj, Sensor):
-            return {
-                'sensor_id': obj.sensor_id,
-                'children': obj.children,
-                'type': obj.type,
-                'sketch_name': obj.sketch_name,
-                'sketch_version': obj.sketch_version,
-                'battery_level': obj.battery_level,
-                'protocol_version': obj.protocol_version,
-            }
-        if isinstance(obj, ChildSensor):
-            return {
-                'id': obj.id,
-                'type': obj.type,
-                'description': obj.description,
-                'values': obj.values,
-            }
-        return json.JSONEncoder.default(self, obj)
-
-
-class MySensorsJSONDecoder(json.JSONDecoder):
-    """JSON decoder."""
-
-    def __init__(self):
-        """Set up decoder."""
-        json.JSONDecoder.__init__(self, object_hook=self.dict_to_object)
-
-    def dict_to_object(self, obj):  # pylint: disable=no-self-use
-        """Return object from dict."""
-        if not isinstance(obj, dict):
-            return obj
-        if 'sensor_id' in obj:
-            sensor = Sensor(obj['sensor_id'])
-            for key, val in obj.items():
-                setattr(sensor, key, val)
-            return sensor
-        elif all(k in obj for k in ['id', 'type', 'values']):
-            child = ChildSensor(
-                obj['id'], obj['type'], obj.get('description', ''))
-            child.values = obj['values']
-            return child
-        elif all(k.isdigit() for k in obj.keys()):
-            return {int(k): v for k, v in obj.items()}
-        return obj

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -2,6 +2,7 @@
 import calendar
 import logging
 import time
+# pylint: disable=no-name-in-module, import-error
 from distutils.version import LooseVersion as parse_ver
 from queue import Queue
 from timeit import default_timer as timer
@@ -9,7 +10,7 @@ from timeit import default_timer as timer
 import voluptuous as vol
 
 from .const import get_const
-from .message import Message, SYSTEM_CHILD_ID
+from .message import SYSTEM_CHILD_ID, Message
 from .ota import OTAFirmware
 from .persistence import Persistence
 from .sensor import ChildSensor, Sensor

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -190,10 +190,7 @@ class Gateway(object):
         return ret
 
     def alert(self, msg):
-        """Tell anyone who wants to know that a sensor was updated.
-
-        Also save sensors if persistence is enabled.
-        """
+        """Tell anyone who wants to know that a sensor was updated."""
         if self.event_callback is not None:
             try:
                 self.event_callback(msg)
@@ -310,6 +307,13 @@ class Gateway(object):
         """Update firwmare of all node_ids in nids."""
         self.ota.make_update(nids, fw_type, fw_ver, fw_path)
 
+    def start_persistence(self):
+        """Load persistence file and schedule saving of persistence file.
+
+        Implement this method in a child class.
+        """
+        raise NotImplementedError
+
 
 class ThreadingGateway(Gateway, threading.Thread):
     """Gateway that implements a new thread."""
@@ -323,7 +327,10 @@ class ThreadingGateway(Gateway, threading.Thread):
         self._cancel_save = None
 
     def send(self, message):
-        """Implement this method in a child class."""
+        """Send a command string to the gateway.
+
+        Implement this method in a child class.
+        """
         raise NotImplementedError
 
     def start_persistence(self):

--- a/mysensors/const.py
+++ b/mysensors/const.py
@@ -1,0 +1,25 @@
+"""Helpers for const."""
+from distutils.version import LooseVersion as parse_ver
+from importlib import import_module
+
+LOADED_CONST = {}
+
+
+def get_const(protocol_version):
+    """Return the const module for the protocol_version."""
+    version = protocol_version
+    if parse_ver('1.5') <= parse_ver(version) < parse_ver('2.0'):
+        path = 'mysensors.const_15'
+    elif parse_ver(version) >= parse_ver('2.2'):
+        path = 'mysensors.const_22'
+    elif parse_ver(version) >= parse_ver('2.1'):
+        path = 'mysensors.const_21'
+    elif parse_ver(version) >= parse_ver('2.0'):
+        path = 'mysensors.const_20'
+    else:
+        path = 'mysensors.const_14'
+    if path in LOADED_CONST:
+        return LOADED_CONST[path]
+    const = import_module(path)
+    LOADED_CONST[path] = const  # Cache the module
+    return const

--- a/mysensors/const.py
+++ b/mysensors/const.py
@@ -1,4 +1,5 @@
 """Helpers for const."""
+# pylint: disable=no-name-in-module, import-error
 from distutils.version import LooseVersion as parse_ver
 from importlib import import_module
 

--- a/mysensors/gateway_serial.py
+++ b/mysensors/gateway_serial.py
@@ -91,7 +91,7 @@ class SerialGateway(ThreadingGateway):
         self.disconnect()  # Disconnect after stop event is set
 
     def send(self, message):
-        """Write a Message to the gateway."""
+        """Write a command string to the gateway."""
         if not message:
             return
         # Lock to make sure only one thread writes at a time to serial port.

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -31,6 +31,7 @@ class TCPGateway(Gateway, threading.Thread):
         self.tcp_disconnect_timer = time.time()
         self.reconnect_timeout = reconnect_timeout
         self._stop_event = threading.Event()
+        self._cancel_save = None
 
     def _check_connection(self):
         """Check if connection is alive every reconnect_timeout seconds."""
@@ -66,7 +67,7 @@ class TCPGateway(Gateway, threading.Thread):
             self.sock = socket.create_connection(
                 self.server_address, self.reconnect_timeout)
             _LOGGER.info('Connected to %s', self.server_address)
-            self.persistence.schedule_save_sensors()
+            self._cancel_save = self.persistence.schedule_save_sensors()
             return True
 
         except TimeoutError:
@@ -96,8 +97,9 @@ class TCPGateway(Gateway, threading.Thread):
         """Stop the background thread."""
         _LOGGER.info('Stopping thread')
         self._stop_event.set()
-        if self.persistence.scheduled_save is not None:
-            self.persistence.scheduled_save.cancel()
+        if self._cancel_save is not None:
+            self._cancel_save()
+            self._cancel_save = None
 
     def _check_socket(self, sock=None, timeout=None):
         """Check if socket is readable/writable."""

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -2,36 +2,29 @@
 import logging
 import select
 import socket
-import threading
 import time
 
-from mysensors import Gateway, Message
+from mysensors import ThreadingGateway, Message
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class TCPGateway(Gateway, threading.Thread):
+class TCPGateway(ThreadingGateway):
     """MySensors TCP ethernet gateway."""
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
 
-    def __init__(self, host, event_callback=None,
-                 persistence=False, persistence_file='mysensors.pickle',
-                 protocol_version='1.4', port=5003, timeout=1.0,
-                 reconnect_timeout=10.0):
+    def __init__(
+            self, host, port=5003, timeout=1.0, reconnect_timeout=10.0,
+            **kwargs):
         """Set up TCP ethernet gateway."""
-        threading.Thread.__init__(self)
-        Gateway.__init__(self, event_callback, persistence,
-                         persistence_file, protocol_version)
-        self.lock = threading.Lock()
+        super().__init__(**kwargs)
         self.sock = None
         self.server_address = (host, port)
         self.timeout = timeout
+        self.reconnect_timeout = reconnect_timeout
         self.tcp_check_timer = time.time()
         self.tcp_disconnect_timer = time.time()
-        self.reconnect_timeout = reconnect_timeout
-        self._stop_event = threading.Event()
-        self._cancel_save = None
 
     def _check_connection(self):
         """Check if connection is alive every reconnect_timeout seconds."""
@@ -67,7 +60,6 @@ class TCPGateway(Gateway, threading.Thread):
             self.sock = socket.create_connection(
                 self.server_address, self.reconnect_timeout)
             _LOGGER.info('Connected to %s', self.server_address)
-            self._cancel_save = self.persistence.schedule_save_sensors()
             return True
 
         except TimeoutError:
@@ -92,14 +84,6 @@ class TCPGateway(Gateway, threading.Thread):
         self.sock.close()
         self.sock = None
         _LOGGER.info('Socket closed at %s.', self.server_address)
-
-    def stop(self):
-        """Stop the background thread."""
-        _LOGGER.info('Stopping thread')
-        self._stop_event.set()
-        if self._cancel_save is not None:
-            self._cancel_save()
-            self._cancel_save = None
 
     def _check_socket(self, sock=None, timeout=None):
         """Check if socket is readable/writable."""
@@ -198,5 +182,3 @@ class TCPGateway(Gateway, threading.Thread):
                     self.fill_queue(self.logic, (line,))
             self._check_connection()
         self.disconnect()
-        if self.persistence:
-            self.persistence.save_sensors()

--- a/mysensors/message.py
+++ b/mysensors/message.py
@@ -1,0 +1,120 @@
+"""Handle messages."""
+import logging
+
+import voluptuous as vol
+
+from .const import get_const
+
+_LOGGER = logging.getLogger(__name__)
+
+BROADCAST_ID = 255
+SYSTEM_CHILD_ID = 255
+
+
+class Message(object):
+    """Represent a message from the gateway."""
+
+    def __init__(self, data=None, gateway=None):
+        """Set up message."""
+        self.node_id = 0
+        self.child_id = 0
+        self.type = 0
+        self.ack = 0
+        self.sub_type = 0
+        self.payload = ''  # All data except payload are integers
+        self.gateway = gateway
+        if data is not None:
+            self.decode(data)
+
+    def __repr__(self):
+        """Return the representation."""
+        return '<Message data="{};{};{};{};{};{}">'.format(
+            self.node_id, self.child_id, self.type, self.ack, self.sub_type,
+            self.payload)
+
+    def copy(self, **kwargs):
+        """Copy a message, optionally replace attributes with kwargs."""
+        msg = Message(self.encode(), self.gateway)
+        for key, val in kwargs.items():
+            setattr(msg, key, val)
+        return msg
+
+    def modify(self, **kwargs):
+        """Modify and return message, replace attributes with kwargs."""
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+        return self
+
+    def decode(self, data, delimiter=';'):
+        """Decode a message from command string."""
+        try:
+            list_data = data.rstrip().split(delimiter)
+            self.payload = list_data.pop()
+            (self.node_id,
+             self.child_id,
+             self.type,
+             self.ack,
+             self.sub_type) = [int(f) for f in list_data]
+        except ValueError:
+            _LOGGER.warning('Error decoding message from gateway, '
+                            'bad data received: %s', data)
+            raise ValueError
+
+    def encode(self, delimiter=';'):
+        """Encode a command string from message."""
+        try:
+            return delimiter.join([str(f) for f in [
+                self.node_id,
+                self.child_id,
+                int(self.type),
+                self.ack,
+                int(self.sub_type),
+                self.payload,
+            ]]) + '\n'
+        except ValueError:
+            _LOGGER.error('Error encoding message to gateway')
+
+    def validate(self, protocol_version):
+        """Validate message."""
+        const = get_const(protocol_version)
+        valid_node_ids = vol.All(vol.Coerce(int), vol.Range(
+            min=0, max=BROADCAST_ID, msg='Not valid node_id: {}'.format(
+                self.node_id)))
+        valid_child_ids = vol.All(vol.Coerce(int), vol.Range(
+            min=0, max=SYSTEM_CHILD_ID, msg='Not valid child_id: {}'.format(
+                self.child_id)))
+        if self.type in (const.MessageType.internal, const.MessageType.stream):
+            valid_child_ids = vol.All(vol.Coerce(int), vol.In(
+                [SYSTEM_CHILD_ID],
+                msg='When message type is {}, child_id must be {}'.format(
+                    self.type, SYSTEM_CHILD_ID)))
+        if (self.type == const.MessageType.internal and
+                self.sub_type in [
+                    const.Internal.I_ID_REQUEST,
+                    const.Internal.I_ID_RESPONSE]):
+            valid_child_ids = vol.Coerce(int)
+        valid_types = vol.All(vol.Coerce(int), vol.In(
+            [member.value for member in const.VALID_MESSAGE_TYPES],
+            msg='Not valid message type: {}'.format(self.type)))
+        if self.child_id == SYSTEM_CHILD_ID:
+            valid_types = vol.All(vol.Coerce(int), vol.In(
+                [const.MessageType.presentation.value,
+                 const.MessageType.internal.value,
+                 const.MessageType.stream.value],
+                msg=(
+                    'When child_id is {}, {} is not a valid '
+                    'message type'.format(SYSTEM_CHILD_ID, self.type))))
+        valid_ack = vol.In([0, 1], msg='Not valid ack flag: {}'.format(
+            self.ack))
+        valid_sub_types = vol.In(
+            [member.value for member
+             in const.VALID_MESSAGE_TYPES.get(self.type, [])],
+            msg='Not valid message sub-type: {}'.format(self.sub_type))
+        valid_payload = const.VALID_PAYLOADS.get(
+            self.type, {}).get(self.sub_type, '')
+        schema = vol.Schema({
+            'node_id': valid_node_ids, 'child_id': valid_child_ids,
+            'type': valid_types, 'ack': valid_ack, 'sub_type': valid_sub_types,
+            'payload': valid_payload})
+        to_validate = {attr: getattr(self, attr) for attr in schema.schema}
+        return schema(to_validate)

--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -1,7 +1,9 @@
 """Convenience module for backwards compatibility."""
 # flake8: noqa: F401
 # pylint: disable=unused-import
-from mysensors import ChildSensor, Gateway, Message, Sensor
+from mysensors import Gateway
 from mysensors.gateway_mqtt import MQTTGateway
 from mysensors.gateway_serial import SerialGateway
 from mysensors.gateway_tcp import TCPGateway
+from mysensors.message import Message
+from mysensors.sensor import ChildSensor, Sensor

--- a/mysensors/persistence.py
+++ b/mysensors/persistence.py
@@ -1,0 +1,172 @@
+"""Handle persistence."""
+import json
+import logging
+import os
+import pickle
+import threading
+
+from .sensor import ChildSensor, Sensor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Persistence(object):
+    """Organize persistence file saving and loading."""
+
+    def __init__(self, sensors, persistence_file='mysensors.pickle'):
+        """Set up Persistence instance."""
+        self.persistence_file = persistence_file
+        self.persistence_bak = '{}.bak'.format(self.persistence_file)
+        self.scheduled_save = None
+        self._sensors = sensors
+
+    def _save_pickle(self, filename):
+        """Save sensors to pickle file."""
+        with open(filename, 'wb') as file_handle:
+            pickle.dump(self._sensors, file_handle, pickle.HIGHEST_PROTOCOL)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+
+    def _load_pickle(self, filename):
+        """Load sensors from pickle file."""
+        with open(filename, 'rb') as file_handle:
+            self._sensors.update(pickle.load(file_handle))
+
+    def _save_json(self, filename):
+        """Save sensors to json file."""
+        with open(filename, 'w') as file_handle:
+            json.dump(self._sensors, file_handle, cls=MySensorsJSONEncoder,
+                      indent=4)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+
+    def _load_json(self, filename):
+        """Load sensors from json file."""
+        with open(filename, 'r') as file_handle:
+            self._sensors.update(json.load(
+                file_handle, cls=MySensorsJSONDecoder))
+
+    def save_sensors(self):
+        """Save sensors to file."""
+        fname = os.path.realpath(self.persistence_file)
+        exists = os.path.isfile(fname)
+        dirname = os.path.dirname(fname)
+        if (not os.access(dirname, os.W_OK) or exists and
+                not os.access(fname, os.W_OK)):
+            _LOGGER.error('Permission denied when writing to %s', fname)
+            return
+        split_fname = os.path.splitext(fname)
+        tmp_fname = '{}.tmp{}'.format(split_fname[0], split_fname[1])
+        self._perform_file_action(tmp_fname, 'save')
+        if exists:
+            os.rename(fname, self.persistence_bak)
+        os.rename(tmp_fname, fname)
+        if exists:
+            os.remove(self.persistence_bak)
+
+    def schedule_save_sensors(self):
+        """Schedule a call to save sensors every 10 seconds.
+
+        Call this method once when the connection is established.
+        """
+        self.save_sensors()
+        self.scheduled_save = threading.Timer(
+            10.0, self.schedule_save_sensors)
+        self.scheduled_save.start()
+
+    def _load_sensors(self, path=None):
+        """Load sensors from file."""
+        if path is None:
+            path = self.persistence_file
+        exists = os.path.isfile(path)
+        if exists and os.access(path, os.R_OK):
+            if path == self.persistence_bak:
+                os.rename(path, self.persistence_file)
+                path = self.persistence_file
+            self._perform_file_action(path, 'load')
+            return True
+        else:
+            _LOGGER.warning('File does not exist or is not readable: %s', path)
+            return False
+
+    def safe_load_sensors(self):
+        """Load sensors safely from file."""
+        try:
+            loaded = self._load_sensors()
+        except (EOFError, ValueError):
+            _LOGGER.error('Bad file contents: %s', self.persistence_file)
+            loaded = False
+        if not loaded:
+            _LOGGER.warning('Trying backup file: %s', self.persistence_bak)
+            try:
+                if not self._load_sensors(self.persistence_bak):
+                    _LOGGER.warning('Failed to load sensors from file: %s',
+                                    self.persistence_file)
+            except (EOFError, ValueError):
+                _LOGGER.error('Bad file contents: %s', self.persistence_file)
+                _LOGGER.warning('Removing file: %s', self.persistence_file)
+                os.remove(self.persistence_file)
+
+    def _perform_file_action(self, filename, action):
+        """Perform action on specific file types.
+
+        Dynamic dispatch function for performing actions on
+        specific file types.
+        """
+        ext = os.path.splitext(filename)[1]
+        func = getattr(self, '_%s_%s' % (action, ext[1:]), None)
+        if func is None:
+            raise Exception('Unsupported file type %s' % ext[1:])
+        func(filename)
+
+
+class MySensorsJSONEncoder(json.JSONEncoder):
+    """JSON encoder."""
+
+    def default(self, obj):
+        """Serialize obj into JSON."""
+        # pylint: disable=method-hidden, protected-access, arguments-differ
+        if isinstance(obj, Sensor):
+            return {
+                'sensor_id': obj.sensor_id,
+                'children': obj.children,
+                'type': obj.type,
+                'sketch_name': obj.sketch_name,
+                'sketch_version': obj.sketch_version,
+                'battery_level': obj.battery_level,
+                'protocol_version': obj.protocol_version,
+            }
+        if isinstance(obj, ChildSensor):
+            return {
+                'id': obj.id,
+                'type': obj.type,
+                'description': obj.description,
+                'values': obj.values,
+            }
+        return json.JSONEncoder.default(self, obj)
+
+
+class MySensorsJSONDecoder(json.JSONDecoder):
+    """JSON decoder."""
+
+    def __init__(self):
+        """Set up decoder."""
+        json.JSONDecoder.__init__(self, object_hook=self.dict_to_object)
+
+    def dict_to_object(self, obj):  # pylint: disable=no-self-use
+        """Return object from dict."""
+        if not isinstance(obj, dict):
+            return obj
+        if 'sensor_id' in obj:
+            sensor = Sensor(obj['sensor_id'])
+            for key, val in obj.items():
+                setattr(sensor, key, val)
+            return sensor
+        elif all(k in obj for k in ['id', 'type', 'values']):
+            child = ChildSensor(
+                obj['id'], obj['type'], obj.get('description', ''))
+            child.values = obj['values']
+            return child
+        elif all(k.isdigit() for k in obj.keys()):
+            return {int(k): v for k, v in obj.items()}
+        return obj

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -1,0 +1,157 @@
+"""Handle sensor classes."""
+import logging
+from collections import deque
+
+import voluptuous as vol
+
+from .const import get_const
+from .message import Message
+from .validation import is_battery_level, safe_is_version
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Sensor(object):
+    """Represent a sensor."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, sensor_id):
+        """Set up sensor."""
+        self.sensor_id = sensor_id
+        self.children = {}
+        self.type = None
+        self.sketch_name = None
+        self.sketch_version = None
+        self._battery_level = 0
+        self._protocol_version = '1.4'
+        self.new_state = {}
+        self.queue = deque()
+        self.reboot = False
+
+    def __getstate__(self):
+        """Get state to save as pickle."""
+        state = self.__dict__.copy()
+        for attr in ('_battery_level', '_protocol_version'):
+            value = state.pop(attr, None)
+            prop = attr
+            if prop.startswith('_'):
+                prop = prop[1:]
+            if value is not None:
+                state[prop] = value
+
+        return state
+
+    def __setstate__(self, state):
+        """Set state when loading pickle."""
+        # Restore instance attributes
+        for key, val in state.items():
+            setattr(self, key, val)
+        # Reset some attributes
+        self.new_state = {}
+        self.queue = deque()
+        self.reboot = False
+
+    def __repr__(self):
+        """Return the representation."""
+        return '<Sensor sensor_id={}, children: {}>'.format(
+            self.sensor_id, self.children)
+
+    @property
+    def battery_level(self):
+        """Return battery level."""
+        return self._battery_level
+
+    @battery_level.setter
+    def battery_level(self, value):
+        """Set valid battery level."""
+        self._battery_level = is_battery_level(value)
+
+    @property
+    def protocol_version(self):
+        """Return protocol version."""
+        return self._protocol_version
+
+    @protocol_version.setter
+    def protocol_version(self, value):
+        """Set valid protocol version."""
+        self._protocol_version = safe_is_version(value)
+
+    def add_child_sensor(self, child_id, child_type, description=''):
+        """Create and add a child sensor."""
+        if child_id in self.children:
+            _LOGGER.warning(
+                'child_id %s already exists in children of node %s, '
+                'cannot add child', child_id, self.sensor_id)
+            return None
+        self.children[child_id] = ChildSensor(
+            child_id, child_type, description)
+        return child_id
+
+    def set_child_value(self, child_id, value_type, value, **kwargs):
+        """Set a child sensor's value."""
+        children = kwargs.get('children', self.children)
+        if not isinstance(children, dict) or child_id not in children:
+            return None
+        msg_type = kwargs.get('msg_type', 1)
+        ack = kwargs.get('ack', 0)
+        msg = Message().modify(
+            node_id=self.sensor_id, child_id=child_id, type=msg_type, ack=ack,
+            sub_type=value_type, payload=value)
+        msg_string = msg.encode()
+        if msg_string is None:
+            _LOGGER.error(
+                'Not a valid message: node %s, child %s, type %s, ack %s, '
+                'sub_type %s, payload %s',
+                self.sensor_id, child_id, msg_type, ack, value_type, value)
+            return None
+        try:
+            msg = Message(msg_string)
+            msg.validate(self.protocol_version)
+        except (ValueError, AttributeError, vol.Invalid) as exc:
+            _LOGGER.error('Not a valid message: %s', exc)
+            return None
+        child = children[msg.child_id]
+        child.values[msg.sub_type] = msg.payload
+        return msg_string
+
+
+class ChildSensor(object):
+    """Represent a child sensor."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, child_id, child_type, description=''):
+        """Set up child sensor."""
+        # pylint: disable=invalid-name
+        self.id = child_id
+        self.type = child_type
+        self.description = description
+        self.values = {}
+
+    def __setstate__(self, state):
+        """Set state when loading pickle."""
+        # Restore instance attributes
+        self.__dict__.update(state)
+        # Make sure all attributes exist
+        if 'description' not in self.__dict__:
+            self.description = ''
+
+    def __repr__(self):
+        """Return the representation."""
+        ret = ('<ChildSensor child_id={0!s}, child_type={1!s}, '
+               'description={2!s}, values: {3!s}>')
+        return ret.format(self.id, self.type, self.description, self.values)
+
+    def get_schema(self, protocol_version):
+        """Return the child schema for the correct const version."""
+        const = get_const(protocol_version)
+        return vol.Schema({
+            typ.value: const.VALID_SETREQ[typ]
+            for typ in const.VALID_TYPES[self.type]})
+
+    def validate(self, protocol_version, values=None):
+        """Validate child value types and values against protocol_version."""
+        if values is None:
+            values = self.values
+        return self.get_schema(protocol_version)(values)

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -119,8 +119,6 @@ class Sensor(object):
 class ChildSensor(object):
     """Represent a child sensor."""
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, child_id, child_type, description=''):
         """Set up child sensor."""
         # pylint: disable=invalid-name

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -1,16 +1,11 @@
 """Test mysensors with unittest."""
-import json
-import os
-import tempfile
 import time
-from collections import deque
 from unittest import TestCase, main, mock
 
 import voluptuous as vol
 
 from mysensors import Gateway
 from mysensors.message import Message
-from mysensors.persistence import MySensorsJSONEncoder, Persistence
 from mysensors.sensor import ChildSensor, Sensor
 
 
@@ -220,210 +215,6 @@ class TestGateway(TestCase):
         """Test req message for non-existent sensor."""
         ret = self.gateway.logic('1;1;2;0;24;\n')
         self.assertEqual(ret, None)
-
-    def _test_persistence(self, filename):
-        """Test persistence."""
-        sensor = self._add_sensor(1)
-        sensor.children[0] = ChildSensor(
-            0, self.gateway.const.Presentation.S_LIGHT_LEVEL, 'test')
-        sensor.children[0].values[
-            self.gateway.const.SetReq.V_LIGHT_LEVEL] = '43'
-        self.gateway.sensors[
-            1].type = self.gateway.const.Presentation.S_ARDUINO_NODE
-        self.gateway.sensors[1].sketch_name = 'testsketch'
-        self.gateway.sensors[1].sketch_version = '1.0'
-        self.gateway.sensors[1].battery_level = 78
-        self.gateway.sensors[1].protocol_version = '1.4.1'
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            persistence_file = os.path.join(temp_dir, filename)
-            self.gateway.persistence = Persistence(
-                self.gateway.sensors, persistence_file)
-            self.gateway.persistence.save_sensors()
-            del self.gateway.sensors[1]
-            self.assertNotIn(1, self.gateway.sensors)
-            self.gateway.persistence.safe_load_sensors()
-            self.assertEqual(
-                self.gateway.sensors[1].sketch_name, sensor.sketch_name)
-            self.assertEqual(self.gateway.sensors[1].sketch_version,
-                             sensor.sketch_version)
-            self.assertEqual(
-                self.gateway.sensors[1].battery_level,
-                sensor.battery_level)
-            self.assertEqual(self.gateway.sensors[1].type, sensor.type)
-            self.assertEqual(self.gateway.sensors[1].protocol_version,
-                             sensor.protocol_version)
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].id,
-                sensor.children[0].id)
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].type,
-                sensor.children[0].type)
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].description,
-                sensor.children[0].description)
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].values,
-                sensor.children[0].values)
-            self.gateway.persistence.save_sensors()
-            del self.gateway.sensors[1]
-            self.assertNotIn(1, self.gateway.sensors)
-            self.gateway.persistence.safe_load_sensors()
-            self.assertIn(1, self.gateway.sensors)
-
-    def test_pickle_persistence(self):
-        """Test persistence using pickle."""
-        self._test_persistence('file.pickle')
-
-    def test_json_persistence(self):
-        """Test persistence using JSON."""
-        self._test_persistence('file.json')
-
-    def test_bad_file_name(self):
-        """Test persistence with bad file name."""
-        self._add_sensor(1)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            persistence_file = os.path.join(temp_dir, 'file.bad')
-            self.gateway.persistence = Persistence(
-                self.gateway.sensors, persistence_file)
-            with self.assertRaises(Exception):
-                self.gateway.persistence.save_sensors()
-
-    def test_json_no_files(self):
-        """Test json persistence with no files existing."""
-        self.assertFalse(self.gateway.sensors)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            persistence_file = os.path.join(temp_dir, 'file.json')
-            self.gateway.persistence = Persistence(
-                self.gateway.sensors, persistence_file)
-            self.gateway.persistence.safe_load_sensors()
-        self.assertFalse(self.gateway.sensors)
-
-    def _test_empty_files(self, filename):
-        """Test persistence with empty files."""
-        self.assertFalse(self.gateway.sensors)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            persistence_file = os.path.join(temp_dir, filename)
-            self.gateway.persistence = Persistence(
-                self.gateway.sensors, persistence_file)
-            persistence = self.gateway.persistence
-            with open(persistence_file, 'w') as file_handle:
-                file_handle.write('')
-            with open(persistence.persistence_bak, 'w') as file_handle:
-                file_handle.write('')
-            self.gateway.persistence.safe_load_sensors()
-        self.assertFalse(self.gateway.sensors)
-
-    def test_pickle_empty_files(self):
-        """Test persistence with empty pickle files."""
-        self._test_empty_files('file.pickle')
-
-    def test_json_empty_files(self):
-        """Test persistence with empty JSON files."""
-        self._test_empty_files('file.json')
-
-    def test_json_empty_file_good_bak(self):
-        """Test json persistence with empty file but good backup."""
-        self._add_sensor(1)
-        self.assertIn(1, self.gateway.sensors)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            persistence_file = os.path.join(temp_dir, 'file.json')
-            self.gateway.persistence = Persistence(
-                self.gateway.sensors, persistence_file)
-            self.gateway.persistence.save_sensors()
-            del self.gateway.sensors[1]
-            os.rename(
-                persistence_file, self.gateway.persistence.persistence_bak)
-            with open(persistence_file, 'w') as json_file:
-                json_file.write('')
-            self.gateway.persistence.safe_load_sensors()
-        self.assertIn(1, self.gateway.sensors)
-
-    @mock.patch('mysensors.persistence.Persistence.safe_load_sensors')
-    def test_persistence_at_init(self, mock_load_sensors):
-        """Test call to load persistence_file at init of Gateway."""
-        self.gateway = Gateway(persistence=True)
-        assert mock_load_sensors.call_count == 1
-
-    def save_json_upgrade(self, filename):
-        """Save sensors to json file.
-
-        Only used for testing upgrade with missing attributes.
-        """
-        with open(filename, 'w') as file_handle:
-            json.dump(
-                self.gateway.sensors, file_handle,
-                cls=MySensorsJSONEncoderTestUpgrade)
-            file_handle.flush()
-            os.fsync(file_handle.fileno())
-
-    @mock.patch('mysensors.persistence.Persistence._save_json')
-    def _test_persistence_upgrade(self, filename, mock_save_json):
-        """Test that all attributes are present after persistence upgrade."""
-        mock_save_json.side_effect = self.save_json_upgrade
-        sensor = self._add_sensor(1)
-        sensor.children[0] = ChildSensor(
-            0, self.gateway.const.Presentation.S_LIGHT_LEVEL)
-        del self.gateway.sensors[1].__dict__['new_state']
-        self.assertNotIn('new_state', self.gateway.sensors[1].__dict__)
-        del self.gateway.sensors[1].__dict__['queue']
-        self.assertNotIn('queue', self.gateway.sensors[1].__dict__)
-        del self.gateway.sensors[1].__dict__['reboot']
-        self.assertNotIn('reboot', self.gateway.sensors[1].__dict__)
-        del self.gateway.sensors[1].__dict__['_battery_level']
-        self.assertNotIn('_battery_level', self.gateway.sensors[1].__dict__)
-        self.gateway.sensors[1].__dict__['battery_level'] = 58
-        del self.gateway.sensors[1].__dict__['_protocol_version']
-        self.assertNotIn('_protocol_version', self.gateway.sensors[1].__dict__)
-        self.gateway.sensors[1].__dict__[
-            'protocol_version'] = self.gateway.protocol_version
-        del self.gateway.sensors[1].children[0].__dict__['description']
-        self.assertNotIn(
-            'description', self.gateway.sensors[1].children[0].__dict__)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            persistence_file = os.path.join(temp_dir, filename)
-            self.gateway.persistence = Persistence(
-                self.gateway.sensors, persistence_file)
-            self.gateway.persistence.save_sensors()
-            del self.gateway.sensors[1]
-            self.assertNotIn(1, self.gateway.sensors)
-            self.gateway.persistence.safe_load_sensors()
-            self.assertEqual(self.gateway.sensors[1].battery_level, 58)
-            self.assertEqual(
-                self.gateway.sensors[1].protocol_version,
-                self.gateway.protocol_version)
-            self.assertEqual(self.gateway.sensors[1].new_state, {})
-            self.assertEqual(self.gateway.sensors[1].queue, deque())
-            self.assertEqual(self.gateway.sensors[1].reboot, False)
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].description, '')
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].id,
-                sensor.children[0].id)
-            self.assertEqual(
-                self.gateway.sensors[1].children[0].type,
-                sensor.children[0].type)
-
-    def test_pickle_upgrade(self):
-        """Test that all attributes are present after pickle upgrade."""
-        # pylint: disable=no-value-for-parameter
-        self._test_persistence_upgrade('file.pickle')
-
-    def test_json_upgrade(self):
-        """Test that all attributes are present after JSON upgrade."""
-        # pylint: disable=no-value-for-parameter
-        self._test_persistence_upgrade('file.json')
-
-    @mock.patch('mysensors.persistence.threading.Timer')
-    @mock.patch('mysensors.persistence.Persistence.save_sensors')
-    def test_schedule_save_sensors(self, mock_save, mock_timer_class):
-        """Test schedule save sensors."""
-        mock_timer = mock.MagicMock()
-        mock_timer_class.return_value = mock_timer
-        self.gateway.persistence = Persistence(self.gateway.sensors)
-        self.gateway.persistence.schedule_save_sensors()
-        assert mock_save.call_count == 1
-        assert mock_timer.start.call_count == 1
 
     def _callback(self, message):
         self.gateway.test_callback_message = message
@@ -863,22 +654,6 @@ def test_gateway_low_protocol():
     """Test initializing gateway with too low protocol_version."""
     gateway = Gateway(protocol_version='1.3')
     assert gateway.protocol_version == '1.4'
-
-
-class MySensorsJSONEncoderTestUpgrade(MySensorsJSONEncoder):
-    """JSON encoder used for testing upgrade with missing attributes."""
-
-    def default(self, obj):  # pylint: disable=E0202
-        """Serialize obj into JSON."""
-        if isinstance(obj, Sensor):
-            return obj.__dict__
-        if isinstance(obj, ChildSensor):
-            return {
-                'id': obj.id,
-                'type': obj.type,
-                'values': obj.values,
-            }
-        return super().default(obj)
 
 
 if __name__ == '__main__':

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,243 @@
+"""Test persistence."""
+import json
+import os
+import tempfile
+from collections import deque
+from unittest import TestCase, mock
+
+from mysensors import Gateway
+from mysensors.sensor import ChildSensor, Sensor
+from mysensors.persistence import MySensorsJSONEncoder, Persistence
+
+
+class TestPersistence(TestCase):
+    """Test the Persistence logic."""
+
+    def setUp(self):
+        """Set up gateway."""
+        self.gateway = Gateway()
+
+    def _add_sensor(self, sensorid):
+        """Add sensor node. Return sensor node instance."""
+        self.gateway.sensors[sensorid] = Sensor(sensorid)
+        return self.gateway.sensors[sensorid]
+
+    def _test_persistence(self, filename):
+        """Test persistence."""
+        sensor = self._add_sensor(1)
+        sensor.children[0] = ChildSensor(
+            0, self.gateway.const.Presentation.S_LIGHT_LEVEL, 'test')
+        sensor.children[0].values[
+            self.gateway.const.SetReq.V_LIGHT_LEVEL] = '43'
+        self.gateway.sensors[
+            1].type = self.gateway.const.Presentation.S_ARDUINO_NODE
+        self.gateway.sensors[1].sketch_name = 'testsketch'
+        self.gateway.sensors[1].sketch_version = '1.0'
+        self.gateway.sensors[1].battery_level = 78
+        self.gateway.sensors[1].protocol_version = '1.4.1'
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persistence_file = os.path.join(temp_dir, filename)
+            self.gateway.persistence = Persistence(
+                self.gateway.sensors, persistence_file)
+            self.gateway.persistence.save_sensors()
+            del self.gateway.sensors[1]
+            self.assertNotIn(1, self.gateway.sensors)
+            self.gateway.persistence.safe_load_sensors()
+            self.assertEqual(
+                self.gateway.sensors[1].sketch_name, sensor.sketch_name)
+            self.assertEqual(self.gateway.sensors[1].sketch_version,
+                             sensor.sketch_version)
+            self.assertEqual(
+                self.gateway.sensors[1].battery_level,
+                sensor.battery_level)
+            self.assertEqual(self.gateway.sensors[1].type, sensor.type)
+            self.assertEqual(self.gateway.sensors[1].protocol_version,
+                             sensor.protocol_version)
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].id,
+                sensor.children[0].id)
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].type,
+                sensor.children[0].type)
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].description,
+                sensor.children[0].description)
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].values,
+                sensor.children[0].values)
+            self.gateway.persistence.save_sensors()
+            del self.gateway.sensors[1]
+            self.assertNotIn(1, self.gateway.sensors)
+            self.gateway.persistence.safe_load_sensors()
+            self.assertIn(1, self.gateway.sensors)
+
+    def test_pickle_persistence(self):
+        """Test persistence using pickle."""
+        self._test_persistence('file.pickle')
+
+    def test_json_persistence(self):
+        """Test persistence using JSON."""
+        self._test_persistence('file.json')
+
+    def test_bad_file_name(self):
+        """Test persistence with bad file name."""
+        self._add_sensor(1)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persistence_file = os.path.join(temp_dir, 'file.bad')
+            self.gateway.persistence = Persistence(
+                self.gateway.sensors, persistence_file)
+            with self.assertRaises(Exception):
+                self.gateway.persistence.save_sensors()
+
+    def test_json_no_files(self):
+        """Test json persistence with no files existing."""
+        self.assertFalse(self.gateway.sensors)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persistence_file = os.path.join(temp_dir, 'file.json')
+            self.gateway.persistence = Persistence(
+                self.gateway.sensors, persistence_file)
+            self.gateway.persistence.safe_load_sensors()
+        self.assertFalse(self.gateway.sensors)
+
+    def _test_empty_files(self, filename):
+        """Test persistence with empty files."""
+        self.assertFalse(self.gateway.sensors)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persistence_file = os.path.join(temp_dir, filename)
+            self.gateway.persistence = Persistence(
+                self.gateway.sensors, persistence_file)
+            persistence = self.gateway.persistence
+            with open(persistence_file, 'w') as file_handle:
+                file_handle.write('')
+            with open(persistence.persistence_bak, 'w') as file_handle:
+                file_handle.write('')
+            self.gateway.persistence.safe_load_sensors()
+        self.assertFalse(self.gateway.sensors)
+
+    def test_pickle_empty_files(self):
+        """Test persistence with empty pickle files."""
+        self._test_empty_files('file.pickle')
+
+    def test_json_empty_files(self):
+        """Test persistence with empty JSON files."""
+        self._test_empty_files('file.json')
+
+    def test_json_empty_file_good_bak(self):
+        """Test json persistence with empty file but good backup."""
+        self._add_sensor(1)
+        self.assertIn(1, self.gateway.sensors)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persistence_file = os.path.join(temp_dir, 'file.json')
+            self.gateway.persistence = Persistence(
+                self.gateway.sensors, persistence_file)
+            self.gateway.persistence.save_sensors()
+            del self.gateway.sensors[1]
+            os.rename(
+                persistence_file, self.gateway.persistence.persistence_bak)
+            with open(persistence_file, 'w') as json_file:
+                json_file.write('')
+            self.gateway.persistence.safe_load_sensors()
+        self.assertIn(1, self.gateway.sensors)
+
+    @mock.patch('mysensors.persistence.Persistence.safe_load_sensors')
+    def test_persistence_at_init(self, mock_load_sensors):
+        """Test call to load persistence_file at init of Gateway."""
+        self.gateway = Gateway(persistence=True)
+        assert mock_load_sensors.call_count == 1
+
+    def save_json_upgrade(self, filename):
+        """Save sensors to json file.
+
+        Only used for testing upgrade with missing attributes.
+        """
+        with open(filename, 'w') as file_handle:
+            json.dump(
+                self.gateway.sensors, file_handle,
+                cls=MySensorsJSONEncoderTestUpgrade)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+
+    @mock.patch('mysensors.persistence.Persistence._save_json')
+    def _test_persistence_upgrade(self, filename, mock_save_json):
+        """Test that all attributes are present after persistence upgrade."""
+        mock_save_json.side_effect = self.save_json_upgrade
+        sensor = self._add_sensor(1)
+        sensor.children[0] = ChildSensor(
+            0, self.gateway.const.Presentation.S_LIGHT_LEVEL)
+        del self.gateway.sensors[1].__dict__['new_state']
+        self.assertNotIn('new_state', self.gateway.sensors[1].__dict__)
+        del self.gateway.sensors[1].__dict__['queue']
+        self.assertNotIn('queue', self.gateway.sensors[1].__dict__)
+        del self.gateway.sensors[1].__dict__['reboot']
+        self.assertNotIn('reboot', self.gateway.sensors[1].__dict__)
+        del self.gateway.sensors[1].__dict__['_battery_level']
+        self.assertNotIn('_battery_level', self.gateway.sensors[1].__dict__)
+        self.gateway.sensors[1].__dict__['battery_level'] = 58
+        del self.gateway.sensors[1].__dict__['_protocol_version']
+        self.assertNotIn('_protocol_version', self.gateway.sensors[1].__dict__)
+        self.gateway.sensors[1].__dict__[
+            'protocol_version'] = self.gateway.protocol_version
+        del self.gateway.sensors[1].children[0].__dict__['description']
+        self.assertNotIn(
+            'description', self.gateway.sensors[1].children[0].__dict__)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persistence_file = os.path.join(temp_dir, filename)
+            self.gateway.persistence = Persistence(
+                self.gateway.sensors, persistence_file)
+            self.gateway.persistence.save_sensors()
+            del self.gateway.sensors[1]
+            self.assertNotIn(1, self.gateway.sensors)
+            self.gateway.persistence.safe_load_sensors()
+            self.assertEqual(self.gateway.sensors[1].battery_level, 58)
+            self.assertEqual(
+                self.gateway.sensors[1].protocol_version,
+                self.gateway.protocol_version)
+            self.assertEqual(self.gateway.sensors[1].new_state, {})
+            self.assertEqual(self.gateway.sensors[1].queue, deque())
+            self.assertEqual(self.gateway.sensors[1].reboot, False)
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].description, '')
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].id,
+                sensor.children[0].id)
+            self.assertEqual(
+                self.gateway.sensors[1].children[0].type,
+                sensor.children[0].type)
+
+    def test_pickle_upgrade(self):
+        """Test that all attributes are present after pickle upgrade."""
+        # pylint: disable=no-value-for-parameter
+        self._test_persistence_upgrade('file.pickle')
+
+    def test_json_upgrade(self):
+        """Test that all attributes are present after JSON upgrade."""
+        # pylint: disable=no-value-for-parameter
+        self._test_persistence_upgrade('file.json')
+
+    @mock.patch('mysensors.persistence.threading.Timer')
+    @mock.patch('mysensors.persistence.Persistence.save_sensors')
+    def test_schedule_save_sensors(self, mock_save, mock_timer_class):
+        """Test schedule save sensors."""
+        mock_timer = mock.MagicMock()
+        mock_timer_class.return_value = mock_timer
+        self.gateway.persistence = Persistence(self.gateway.sensors)
+        self.gateway.persistence.schedule_save_sensors()
+        assert mock_save.call_count == 1
+        assert mock_timer.start.call_count == 1
+
+
+class MySensorsJSONEncoderTestUpgrade(MySensorsJSONEncoder):
+    """JSON encoder used for testing upgrade with missing attributes."""
+
+    def default(self, obj):  # pylint: disable=E0202
+        """Serialize obj into JSON."""
+        if isinstance(obj, Sensor):
+            return obj.__dict__
+        if isinstance(obj, ChildSensor):
+            return {
+                'id': obj.id,
+                'type': obj.type,
+                'values': obj.values,
+            }
+        return super().default(obj)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -140,12 +140,6 @@ class TestPersistence(TestCase):
             self.gateway.persistence.safe_load_sensors()
         self.assertIn(1, self.gateway.sensors)
 
-    @mock.patch('mysensors.persistence.Persistence.safe_load_sensors')
-    def test_persistence_at_init(self, mock_load_sensors):
-        """Test call to load persistence_file at init of Gateway."""
-        self.gateway = Gateway(persistence=True)
-        assert mock_load_sensors.call_count == 1
-
     def save_json_upgrade(self, filename):
         """Save sensors to json file.
 


### PR DESCRIPTION
**Breaking change**
* The persistence file is no longer loaded at gateway init. Use the new method `start_persistence`, to load the persistence file. This must be called before starting the thread loop of the gateway, if persistence is used, to ensure persistence file is loaded before communication starts.
* The order of gateway keyword arguments has changed to clarify and simplify class inheritance.

---

**Summary of changes**
* Break out the persistence logic into a class.
* Move the different classes to their own relevant modules. This needs to be done to avoid cyclic imports.
* Fix tests.
* Break out persistence tests into new module.
* Break out threading gateway class, ThreadingGateway. Change order of gateway keyword arguments to clarify and simplify class inheritence.
* Move persistence file loading, saving and scheduling of saving to own method on ThreadingGateway. This allows future use of asyncio. The new method is called `start_persistence`. This must be called before starting the thread loop of the gateway, if persistence is used, to ensure persistence file is loaded before communication starts. This also allows the user control over when persistence should be loaded.