### PR TITLE
Update release instructions to use markdown readme

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,9 +18,9 @@
 	password = password
 	```
   There's a new API for PyPi, see this [page](https://packaging.python.org/guides/migrating-to-pypi-org/#uploading) for more info.
-- Install `twine` v1.8.0+.
+- Install the pypi requirements including `twine`.
   ```
-  pip3 install --upgrade twine
+  pip3 install -r requirements_pypi.txt
   ```
 - Create a release branch from dev.
 - Merge master into the release branch to make the PR mergeable.
@@ -31,15 +31,22 @@
 - Merge the pull request into master, do not squash.
 - Go to github releases and tag a new release on the master branch. Put the PR message as the description for the release.
 - Fetch and checkout the master branch.
-- Generate `README.rst` by running `scripts/gen_rst` (pandoc needed).
 - Build source and wheel distributions:
   ```
   rm -rf build
   rm -rf dist
   python3 setup.py sdist bdist_wheel
   ```
-- Stage release: `twine upload -r testpypi dist/*`
-- Release: `twine upload -r pypi dist/*`
+- Stage release (upload distributions one at a time to avoid bug, see this [blog](https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi)):
+  ```
+  twine upload -r testpypi dist/*.tar.gz
+  twine upload -r testpypi dist/*.whl
+  ```
+- Release:
+  ```
+  twine upload -r pypi dist/*.tar.gz
+  twine upload -r pypi dist/*.whl
+  ```
 - Fetch and checkout the develop branch.
 - Merge master into develop.
 - Update version in `mysensors/version.py` to the new develop version number, eg `'0.3.0.dev0'`

--- a/requirements_pypi.txt
+++ b/requirements_pypi.txt
@@ -1,2 +1,3 @@
-twine>=1.8.1
+setuptools>=38.6.0
+twine>=1.11.0
 wheel>=0.29.0

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,9 @@
 """Setup file for mysensors package."""
-import os
 from setuptools import setup, find_packages
 
 exec(open('mysensors/version.py').read())
 
-if os.path.exists('README.rst'):
-    README = open('README.rst').read()
-else:
-    README = ''
+README = open('README.md').read()
 
 REQUIRES = [
     'pyserial>=3.2.1', 'pyserial-asyncio>=0.4', 'crcmod>=1.7', 'IntelHex>=2.1',
@@ -19,6 +15,7 @@ setup(
     version=__version__,
     description='Python API for talking to a MySensors gateway',
     long_description=README,
+    long_description_content_type='text/markdown',
     url='https://github.com/theolind/pymysensors',
     author='Theodor Lindquist',
     author_email='theodor.lindquist@gmail.com',


### PR DESCRIPTION
* PYPI at https://pypi.org/ now supports rendering markdown for the description. The legacy site http://pypi.python.org/ will not render the markdown, but this site will soon be closed down and redirect to the new site. See https://wiki.python.org/psf/WarehouseRoadmap.