### PR TITLE
Call event callback when gateway is ready

### DIFF
--- a/mysensors/const_14.py
+++ b/mysensors/const_14.py
@@ -338,5 +338,5 @@ HANDLE_INTERNAL = {
     Internal.I_LOG_MESSAGE: {
         'log': 'debug'},
     Internal.I_GATEWAY_READY: {
-        'log': 'info'},
+        'log': 'info', 'fun': 'alert'},
 }

--- a/mysensors/const_20.py
+++ b/mysensors/const_20.py
@@ -352,7 +352,7 @@ VALID_PAYLOADS = {
 HANDLE_INTERNAL = dict(HANDLE_INTERNAL)
 HANDLE_INTERNAL.update({
     Internal.I_GATEWAY_READY: {
-        'log': 'info', 'msg': {
+        'log': 'info', 'fun': 'alert', 'msg': {
             'node_id': 255, 'ack': 0, 'sub_type': Internal.I_DISCOVER,
             'payload': ''}},
     Internal.I_HEARTBEAT_RESPONSE: {

--- a/mysensors/const_21.py
+++ b/mysensors/const_21.py
@@ -101,7 +101,7 @@ VALID_PAYLOADS = {
 HANDLE_INTERNAL = dict(HANDLE_INTERNAL)
 HANDLE_INTERNAL.update({
     Internal.I_GATEWAY_READY: {
-        'log': 'info', 'msg': {
+        'log': 'info', 'fun': 'alert', 'msg': {
             'node_id': 255, 'ack': 0, 'sub_type': Internal.I_DISCOVER_REQUEST,
             'payload': ''}},
 })


### PR DESCRIPTION
* Alert whoever is listening that the gateway is ready. MySensors only reports this for serial and tcp ethernet gateways, not MQTT gateways.