### PR TITLE
Fix node presentation after id request

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -67,11 +67,11 @@ class Gateway(object):
             # this is a presentation of the sensor platform
             sensorid = self.add_sensor(msg.node_id)
             if sensorid is None:
-                if msg.node_id in self.sensors:
-                    self.sensors[msg.node_id].reboot = False
                 return None
             self.sensors[msg.node_id].type = msg.sub_type
             self.sensors[msg.node_id].protocol_version = msg.payload
+            # Set reboot to False after a node reboot.
+            self.sensors[msg.node_id].reboot = False
             self.alert(msg)
             return msg
         else:
@@ -233,8 +233,7 @@ class Gateway(object):
             sensorid = self._get_next_id()
         if sensorid is not None and sensorid not in self.sensors:
             self.sensors[sensorid] = Sensor(sensorid)
-            return sensorid
-        return None
+        return sensorid if sensorid in self.sensors else None
 
     def is_sensor(self, sensorid, child_id=None):
         """Return True if a sensor and its child exist."""

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -411,6 +411,17 @@ class TestGateway15(TestGateway):
             sensor.children[0].values[self.gateway.const.SetReq.V_RGBW],
             'ffffffff')
 
+    def test_id_request_and_presentation(self):
+        """Test id request with subsequent presentation."""
+        ret = self.gateway.logic('255;255;3;0;3;\n')
+        self.assertEqual(ret, '255;255;3;0;4;1\n')
+        self.assertIn(1, self.gateway.sensors)
+        self.gateway.logic('1;255;0;0;17;1.5.0\n')
+        self.assertEqual(
+            self.gateway.sensors[1].type,
+            self.gateway.const.Presentation.S_ARDUINO_NODE)
+        self.assertEqual(self.gateway.sensors[1].protocol_version, '1.5.0')
+
 
 class TestGateway20(TestGateway):
     """Use protocol_version 2.0."""

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -411,7 +411,7 @@ class TestGateway15(TestGateway):
             sensor.children[0].values[self.gateway.const.SetReq.V_RGBW],
             'ffffffff')
 
-    def test_id_request_and_presentation(self):
+    def test_id_request_presentation(self):
         """Test id request with subsequent presentation."""
         ret = self.gateway.logic('255;255;3;0;3;\n')
         self.assertEqual(ret, '255;255;3;0;4;1\n')


### PR DESCRIPTION
* Type and protocol version was not set if sensor node was already created by id request.