### PR TITLE
Add unique id for gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,18 @@ continue until all blocks of firmware are sent. If the CRC of the transmitted
 firmware match the CRC of the firmware config response, the node will restart
 and load the new firmware.
 
+## Gateway id
+The gateway method `get_gateway_id` will try to return a unique id for the
+gateway. This will be the serial number of the usb device for serial gateways,
+the mac address of the connected gateway for tcp gateways or the publish topic
+prefix (in_prefix) for mqtt gateways.
+
 ## Async gateway
 The serial, TCP and MQTT gateways now also have versions that support asyncio. Use the
 `AsyncSerialGateway` class, `AsyncTCPGateway` class or `AsyncMQTTGateway` class to make a gateway that
 uses asyncio. The following public methods are coroutines in the async gateway:
 
+- get_gateway_id
 - start_persistence
 - start
 - stop

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -320,6 +320,10 @@ class Gateway(object):
                 self.sensors[sensor_id].set_child_value, child_id, value_type,
                 value, **kwargs))
 
+    def get_gateway_id(self):
+        """Return a unique id for the gateway."""
+        raise NotImplementedError
+
     def send(self, message):
         """Send a command string to the gateway.
 

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -119,6 +119,10 @@ class BaseMQTTGateway(Gateway):
             int(self.const.MessageType.stream)))
         self._handle_subscription(topics)
 
+    def get_gateway_id(self):
+        """Return a unique id for the gateway."""
+        return self._in_prefix if self._in_prefix else None
+
     def recv(self, topic, payload, qos):
         """Receive a MQTT message.
 
@@ -171,3 +175,8 @@ class AsyncMQTTGateway(BaseMQTTGateway, BaseAsyncGateway):
     def _connect(self):
         """Connect to the transport."""
         self._init_topics()
+
+    @asyncio.coroutine
+    def get_gateway_id(self):
+        """Return a unique id for the gateway."""
+        return super().get_gateway_id()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+crcmod>=1.7
+get-mac>=0.2.1
+IntelHex>=2.2.1
 pyserial>=3.4
 pyserial-asyncio>=0.4
-IntelHex>=2.2.1
-crcmod>=1.7
 voluptuous==0.11.1

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ exec(open('mysensors/version.py').read())
 README = open('README.md').read()
 
 REQUIRES = [
-    'pyserial>=3.4', 'pyserial-asyncio>=0.4', 'crcmod>=1.7',
-    'IntelHex>=2.2.1', 'voluptuous==0.11.1',
+    'crcmod>=1.7', 'get-mac>=0.2.1', 'IntelHex>=2.2.1', 'pyserial>=3.4',
+    'pyserial-asyncio>=0.4', 'voluptuous>=0.11.1',
 ]
 
 setup(

--- a/tests/test_gateway_mqtt.py
+++ b/tests/test_gateway_mqtt.py
@@ -225,3 +225,12 @@ def test_nested_prefix(mock_pub, mock_sub):
     gateway.send(ret)
     assert mock_pub.call_args == mock.call(
         'test/test-out/1/1/1/1/1', '20', 1, True)
+
+
+def test_get_gateway_id(mock_pub, mock_sub):
+    """Test get_gateway_id method."""
+    gateway = get_gateway(
+        mock_pub, mock_sub, in_prefix='test/test-in',
+        out_prefix='test/test-out')
+    gateway_id = gateway.get_gateway_id()
+    assert gateway_id == 'test/test-in'


### PR DESCRIPTION
* Add a method get_gateway_id for each gateway type that should return a unique id for the gateway if possible. If it's not possible the method will return None.
* On async gateways the method get_gateway_id is a coroutine.
* Add dependency get-mac to look up mac address using ip address.
* Add a test for mqtt gateway.