### PR TITLE
Fix threading gateway persistence scheduling

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -377,7 +377,7 @@ class ThreadingGateway(Gateway):
     def _create_scheduler(self, save_sensors):
         """Return function to schedule saving sensors."""
         def schedule_save():
-            """Return a function to cancel the schedule."""
+            """Save sensors and schedule a new save."""
             save_sensors()
             scheduler = threading.Timer(10.0, schedule_save)
             scheduler.start()
@@ -505,7 +505,7 @@ class BaseAsyncGateway(BaseTransportGateway):
         """Return function to schedule saving sensors."""
         @asyncio.coroutine
         def schedule_save():
-            """Return a function to cancel the schedule."""
+            """Save sensors and schedule a new save."""
             yield from self.loop.run_in_executor(None, save_sensors)
             callback = partial(
                 ensure_future, schedule_save(), loop=self.loop)

--- a/mysensors/persistence.py
+++ b/mysensors/persistence.py
@@ -3,35 +3,21 @@ import json
 import logging
 import os
 import pickle
-import threading
 
 from .sensor import ChildSensor, Sensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def create_scheduler(save_sensors):
-    """Return function to schedule saving sensors."""
-    def schedule_save():
-        """Return a function to cancel the schedule."""
-        save_sensors()
-        scheduler = threading.Timer(10.0, schedule_save)
-        scheduler.start()
-        return scheduler.cancel
-    return schedule_save
-
-
 class Persistence(object):
     """Organize persistence file saving and loading."""
 
     def __init__(
-            self, sensors, persistence_file='mysensors.pickle',
-            schedule_factory=None):
+            self, sensors, schedule_factory,
+            persistence_file='mysensors.pickle'):
         """Set up Persistence instance."""
         self.persistence_file = persistence_file
         self.persistence_bak = '{}.bak'.format(self.persistence_file)
-        if schedule_factory is None:
-            schedule_factory = create_scheduler
         self.schedule_save_sensors = schedule_factory(self.save_sensors)
         self._sensors = sensors
         self.need_save = True


### PR DESCRIPTION
* Move threading persistence scheduler to threading gateway base class.
* Update threading gateway to use scheduler.
* Fix tests.
* Add test for threading persistence scheduling.

fixes #153 