### PR TITLE
handle case where transport=None

### DIFF
--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -160,7 +160,7 @@ class AsyncTCPGateway(BaseTCPGateway, BaseAsyncGateway):
             super()._check_connection()
         except OSError as exc:
             _LOGGER.error(exc)
-            if self.protocol.transport:
+            if self.protocol and self.protocol.transport:
                 self.protocol.transport.close()
             else:
                 _LOGGER.info("failed to close transport, continuing anyway")

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -160,7 +160,10 @@ class AsyncTCPGateway(BaseTCPGateway, BaseAsyncGateway):
             super()._check_connection()
         except OSError as exc:
             _LOGGER.error(exc)
-            self.protocol.transport.close()
+            if self.protocol.transport:
+                self.protocol.transport.close()
+            else:
+                _LOGGER.info("failed to close transport, continuing anyway")
             self.protocol.conn_lost_callback()
             return
         self.loop.call_later(


### PR DESCRIPTION
Wifi devices tend to disconnect. The existing reconnect code works sometimes, but other times I get errors such as this:

> Traceback (most recent call last):
>   File "/usr/lib/python3.5/asyncio/events.py", line 126, in _run
>     self._callback(*self._args)
>   File "/srv/homeassistant/lib/python3.5/site-packages/mysensors/gateway_tcp.py", line 147, in _check_connection
>     self.protocol.transport.close()
> AttributeError: 'NoneType' object has no attribute 'close'

By checking self.protocol.transport for null, we avoid that error. I have tested this in my system and it cleared up my issues.

You might want to skip the logging. I added it for debugging purposes mostly.