### PR TITLE
Update travis and tox python envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ cache: pip
 python:
   - "3.4"
   - "3.5"
-  - "3.5-dev"
   - "3.6"
-  - "3.6-dev"
-  # nightly now points to 3.7-dev,
-  # which is not supported by latest released tox version
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 # command to install dependencies
 install: pip install -U tox-travis
 # command to run tests

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -13,9 +13,7 @@ try:
     from asyncio import ensure_future  # pylint: disable=ungrouped-imports
 except ImportError:
     # Python 3.4.3 and earlier has this as async
-    # pylint: disable=unused-import
-    from asyncio import async  # pylint: disable=ungrouped-imports
-    ensure_future = async
+    ensure_future = getattr(asyncio, 'async')
 
 import serial.threaded
 import voluptuous as vol

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, lint
+envlist = py34, py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [travis]


### PR DESCRIPTION
* Enable python 3.7 via workaround.
* Remove not needed dev versions.
* Add python 3.7 to tox envs.
* Fix async keyword in python 3.7.