### PR TITLE
Allow custom V_VAR1-5 for any child type

### DIFF
--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -157,7 +157,10 @@ class ChildSensor:
     def get_schema(self, protocol_version):
         """Return the child schema for the correct const version."""
         const = get_const(protocol_version)
-        return vol.Schema({
+        custom_schema = vol.Schema({
+            typ.value: const.VALID_SETREQ[typ]
+            for typ in const.VALID_TYPES[const.Presentation.S_CUSTOM]})
+        return custom_schema.extend({
             typ.value: const.VALID_SETREQ[typ]
             for typ in const.VALID_TYPES[self.type]})
 

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -486,6 +486,10 @@ def test_child_validate(gateway, add_sensor):
     sensor.children[0].validate(gateway.protocol_version)
     assert (
         sensor.children[0].values[gateway.const.SetReq.V_LIGHT_LEVEL] == '43')
+    sensor.children[0].values[gateway.const.SetReq.V_VAR1] = 'custom'
+    sensor.children[0].validate(gateway.protocol_version)
+    assert (
+        sensor.children[0].values[gateway.const.SetReq.V_VAR1] == 'custom')
     sensor.children[0].values[gateway.const.SetReq.V_TRIPPED] = '1'
     with pytest.raises(vol.Invalid):
         sensor.children[0].validate(gateway.protocol_version)


### PR DESCRIPTION
* Allow V_VAR1-5, V_CUSTOM and V_UNIT_PREFIX for any child if supported by version.