### PR TITLE
Add pytest sugar

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,6 @@ flake8==3.6.0
 pylint==2.1.1
 pytest==3.9.3
 pytest-cov==2.6.0
+pytest-sugar==0.9.2
 pytest-timeout==1.3.2
 pydocstyle==3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ skip_missing_interpreters = True
 
 [travis]
 python =
-  3.5: py35, lint
+  3.4: py34, lint
 
 [testenv]
 commands =
-     py.test -v --timeout=30 --cov=mysensors --cov-report= {posargs}
+     pytest --timeout=30 --cov=mysensors --cov-report= {posargs}
 deps =
      -rrequirements.txt
      -rrequirements_test.txt


### PR DESCRIPTION
* Add pytest-sugar.
* Run pytest with default verbosity.
* Run travis lint under lowest supported python version (3.4).