### PR TITLE
 Refactor gateway into task and transport classes

### DIFF
--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -1,22 +1,17 @@
 """Python implementation of MySensors API."""
 import asyncio
 import logging
-import threading
-import time
-from collections import deque
+
 # pylint: disable=no-name-in-module, import-error
 from distutils.version import LooseVersion as parse_ver
 from functools import partial
-from timeit import default_timer as timer
 
-import serial.threaded
 import voluptuous as vol
 
 from .const import SYSTEM_CHILD_ID, get_const
 from .message import Message
-from .ota import OTAFirmware, load_fw
-from .persistence import Persistence
 from .sensor import Sensor
+from .task import AsyncTasks, SyncTasks
 from .validation import safe_is_version
 from .version import __version__  # noqa: F401
 
@@ -26,29 +21,26 @@ _LOGGER = logging.getLogger(__name__)
 class Gateway:
     """Base implementation for a MySensors Gateway."""
 
-    # pylint: disable=too-many-instance-attributes, too-many-arguments
+    # pylint: disable=too-many-instance-attributes, unused-argument
 
-    def __init__(self, event_callback=None, persistence=False,
-                 persistence_file='mysensors.pickle',
-                 persistence_scheduler=None, protocol_version='1.4'):
+    def __init__(
+            self, event_callback=None, persistence=False,
+            persistence_file='mysensors.pickle', protocol_version='1.4',
+            **kwargs):
         """Set up Gateway."""
-        super().__init__()
-        self.queue = deque()
+        protocol_version = safe_is_version(protocol_version)
+        self.const = get_const(protocol_version)
         self.event_callback = event_callback
-        self.sensors = {}
         self.metric = True  # if true - use metric, if false - use imperial
-        if persistence:
-            self.persistence = Persistence(
-                self.sensors, persistence_scheduler, persistence_file)
-        else:
-            self.persistence = None
-        self.protocol_version = safe_is_version(protocol_version)
-        self.const = get_const(self.protocol_version)
         handlers = self.const.get_handler_registry()
         # Copy to allow safe modification.
         self.handlers = dict(handlers)
-        self.ota = OTAFirmware(self.sensors, self.const)
         self.can_log = False
+        self.persistence = persistence
+        self.persistence_file = persistence_file
+        self.protocol_version = protocol_version
+        self.sensors = {}
+        self.tasks = None
 
     def __repr__(self):
         """Return the representation."""
@@ -69,10 +61,9 @@ class Gateway:
 
         message_type = self.const.MessageType(msg.type)
         handler = message_type.get_handler(self.handlers)
-        ret = handler(msg)
-        ret = self._route_message(ret)
-        ret = ret.encode() if ret else None
-        return ret
+        msg = handler(msg)
+        msg = self._route_message(msg)
+        return msg.encode() if msg else None
 
     def alert(self, msg):
         """Tell anyone who wants to know that a sensor was updated."""
@@ -82,8 +73,8 @@ class Gateway:
             except Exception as exception:  # pylint: disable=broad-except
                 _LOGGER.exception(exception)
 
-        if self.persistence:
-            self.persistence.need_save = True
+        if self.tasks.persistence:
+            self.tasks.persistence.need_save = True
 
     def _get_next_id(self):
         """Return the next available sensor id."""
@@ -120,7 +111,7 @@ class Gateway:
                 type=self.const.MessageType.internal,
                 sub_type=self.const.Internal.I_PRESENTATION)
             if self._route_message(msg):
-                self.add_job(msg.encode)
+                self.tasks.add_job(msg.encode)
         return ret
 
     def _route_message(self, msg):
@@ -133,37 +124,6 @@ class Gateway:
             return msg
         self.sensors[msg.node_id].queue.append(msg.encode())
         return None
-
-    def run_job(self, job=None):
-        """Run a job, either passed in or from the queue.
-
-        A job is a tuple of function and optional args. Keyword arguments
-        can be passed via use of functools.partial. The job should return a
-        string that should be sent by the gateway protocol. The function will
-        be called with the arguments and the result will be returned.
-        """
-        if job is None:
-            if not self.queue:
-                return None
-            job = self.queue.popleft()
-        start = timer()
-        func, args = job
-        reply = func(*args)
-        end = timer()
-        if end - start > 0.1:
-            _LOGGER.debug(
-                'Handle queue with call %s(%s) took %.3f seconds',
-                func, args, end - start)
-        return reply
-
-    def add_job(self, func, *args):
-        """Add a job that should return a reply to be sent.
-
-        A job is a tuple of function and optional args. Keyword arguments
-        can be passed via use of functools.partial. The job should return a
-        string that should be sent by the gateway protocol.
-        """
-        self.queue.append((func, args))
 
     def set_child_value(
             self, sensor_id, child_id, value_type, value, **kwargs):
@@ -184,275 +144,68 @@ class Gateway:
                 child_id, value_type, value,
                 children=self.sensors[sensor_id].new_state)
         else:
-            self.add_job(partial(
+            self.tasks.add_job(partial(
                 self.sensors[sensor_id].set_child_value, child_id, value_type,
                 value, **kwargs))
 
-    def get_gateway_id(self):
-        """Return a unique id for the gateway."""
-        raise NotImplementedError
-
     def send(self, message):
-        """Send a command string to the gateway.
-
-        Implement this method in a child class.
-        """
-        raise NotImplementedError
-
-    def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
-        """Update firwmare of all node_ids in nids.
-
-        Implement this method in a child class.
-        """
-        raise NotImplementedError
-
-    def start_persistence(self):
-        """Load persistence file and schedule saving of persistence file.
-
-        Implement this method in a child class.
-        """
-        raise NotImplementedError
-
-
-class ThreadingGateway(Gateway):
-    """Gateway that implements a new thread."""
-
-    def __init__(self, *args, **kwargs):
-        """Set up gateway instance."""
-        super().__init__(
-            *args, persistence_scheduler=self._create_scheduler, **kwargs)
-        self.lock = threading.Lock()
-        self._stop_event = threading.Event()
-        self._cancel_save = None
+        """Write a message to the arduino gateway."""
+        self.tasks.transport.send(message)
 
     def start(self):
-        """Start the connection to a transport."""
-        connect_thread = threading.Thread(target=self._connect)
-        connect_thread.start()
+        """Start the gateway and task allow tasks to be scheduled."""
+        self.tasks.start()
 
-    def _connect(self):
-        raise NotImplementedError
-
-    def _poll_queue(self):
-        """Poll the queue for work."""
-        while not self._stop_event.is_set():
-            reply = self.run_job()
-            self.send(reply)
-            if self.queue:
-                continue
-            time.sleep(0.02)
-
-    def _create_scheduler(self, save_sensors):
-        """Return function to schedule saving sensors."""
-        def schedule_save():
-            """Save sensors and schedule a new save."""
-            save_sensors()
-            scheduler = threading.Timer(10.0, schedule_save)
-            scheduler.start()
-            self._cancel_save = scheduler.cancel
-        return schedule_save
+    def stop(self):
+        """Stop the gateway and stop allowing tasks for the scheduler."""
+        self.tasks.stop()
 
     def start_persistence(self):
         """Load persistence file and schedule saving of persistence file."""
-        if not self.persistence:
-            return
-        self.persistence.safe_load_sensors()
-        self.persistence.schedule_save_sensors()
-
-    def stop(self):
-        """Stop the background thread."""
-        self._stop_event.set()
-        if not self.persistence:
-            return
-        if self._cancel_save is not None:
-            self._cancel_save()
-            self._cancel_save = None
-        self.persistence.save_sensors()
+        self.tasks.start_persistence()
 
     def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
         """Update firwmare of all node_ids in nids."""
-        fw_bin = None
-        if fw_path:
-            fw_bin = load_fw(fw_path)
-            if not fw_bin:
-                return
-        self.ota.make_update(nids, fw_type, fw_ver, fw_bin)
+        self.tasks.update_fw(nids, fw_type, fw_ver, fw_path=fw_path)
 
 
-class BaseTransportGateway(Gateway):
-    """MySensors base gateway for a transport."""
+class BaseSyncGateway(Gateway):
+    """MySensors base sync gateway."""
 
-    # pylint: disable=abstract-method
-
-    def __init__(self, timeout=1.0, reconnect_timeout=10.0, **kwargs):
+    def __init__(self, transport, *args, **kwargs):
         """Set up gateway."""
-        super().__init__(**kwargs)
-        self.timeout = timeout
-        self.reconnect_timeout = reconnect_timeout
-        self.protocol = None
-
-    def _disconnect(self):
-        """Disconnect from the transport."""
-        if not self.protocol or not self.protocol.transport:
-            self.protocol = None  # Make sure protocol is None
-            return
-        _LOGGER.info('Disconnecting from gateway')
-        self.protocol.transport.close()
-        self.protocol = None
-
-    def send(self, message):
-        """Write a message to the gateway."""
-        if not message or not self.protocol or not self.protocol.transport:
-            return
-        if not self.can_log:
-            _LOGGER.debug('Sending %s', message.strip())
-        try:
-            self.protocol.transport.write(message.encode())
-        except OSError as exc:
-            _LOGGER.error(
-                'Failed writing to transport %s: %s',
-                self.protocol.transport, exc)
-            self.protocol.transport.close()
-            self.protocol.conn_lost_callback()
+        super().__init__(*args, **kwargs)
+        self.tasks = SyncTasks(
+            self.const, self.persistence, self.persistence_file, self.sensors,
+            transport)
 
 
-class BaseAsyncGateway(BaseTransportGateway):
+class BaseAsyncGateway(Gateway):
     """MySensors base async gateway."""
 
-    def __init__(self, *args, loop=None, protocol=None, **kwargs):
-        """Set up async serial gateway."""
-        super().__init__(
-            *args, persistence_scheduler=self._create_scheduler, **kwargs)
-        self.loop = loop or asyncio.get_event_loop()
-        self.connect_task = None
-
-        def conn_lost():
-            """Handle connection_lost in protocol class."""
-            # pylint: disable=deprecated-method
-            self.connect_task = self.loop.create_task(self._connect())
-
-        if not protocol:
-            protocol = AsyncMySensorsProtocol
-        self.protocol = protocol(self, conn_lost)
-        self._cancel_save = None
-
-    @asyncio.coroutine
-    def _connect(self):
-        """Connect to the transport."""
-        raise NotImplementedError
+    def __init__(self, transport, *args, loop=None, **kwargs):
+        """Set up gateway."""
+        super().__init__(*args, **kwargs)
+        self.tasks = AsyncTasks(
+            self.const, self.persistence, self.persistence_file, self.sensors,
+            transport, loop=loop)
 
     @asyncio.coroutine
     def start(self):
-        """Start the connection to a transport."""
-        yield from self._connect()
+        """Start the gateway and task allow tasks to be scheduled."""
+        yield from self.tasks.start()
 
     @asyncio.coroutine
     def stop(self):
-        """Stop the gateway."""
-        _LOGGER.info('Stopping gateway')
-        self._disconnect()
-        if self.connect_task and not self.connect_task.cancelled():
-            self.connect_task.cancel()
-            self.connect_task = None
-        if not self.persistence:
-            return
-        if self._cancel_save is not None:
-            self._cancel_save()
-            self._cancel_save = None
-        yield from self.loop.run_in_executor(
-            None, self.persistence.save_sensors)
-
-    def add_job(self, func, *args):
-        """Add a job that should return a reply to be sent.
-
-        A job is a tuple of function and optional args. Keyword arguments
-        can be passed via use of functools.partial. The job should return a
-        string that should be sent by the gateway protocol.
-
-        The async version of this method will send the reply directly.
-        """
-        job = func, args
-        reply = self.run_job(job)
-        self.send(reply)
-
-    def _create_scheduler(self, save_sensors):
-        """Return function to schedule saving sensors."""
-        @asyncio.coroutine
-        def schedule_save():
-            """Save sensors and schedule a new save."""
-            yield from self.loop.run_in_executor(None, save_sensors)
-            callback = partial(self.loop.create_task, schedule_save())
-            task = self.loop.call_later(10.0, callback)
-            self._cancel_save = task.cancel
-        return schedule_save
+        """Stop the gateway and stop allowing tasks for the scheduler."""
+        yield from self.tasks.stop()
 
     @asyncio.coroutine
     def start_persistence(self):
         """Load persistence file and schedule saving of persistence file."""
-        if not self.persistence:
-            return
-        yield from self.loop.run_in_executor(
-            None, self.persistence.safe_load_sensors)
-        yield from self.persistence.schedule_save_sensors()
+        yield from self.tasks.start_persistence()
 
     @asyncio.coroutine
     def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
-        """Start update firwmare of all node_ids in nids in executor."""
-        fw_bin = None
-        if fw_path:
-            fw_bin = yield from self.loop.run_in_executor(
-                None, load_fw, fw_path)
-            if not fw_bin:
-                return
-        self.ota.make_update(nids, fw_type, fw_ver, fw_bin)
-
-
-class BaseMySensorsProtocol(serial.threaded.LineReader):
-    """MySensors base protocol class."""
-
-    TERMINATOR = b'\n'
-
-    def __init__(self, gateway, conn_lost_callback):
-        """Set up base protocol."""
-        super().__init__()
-        self.gateway = gateway
-        self.conn_lost_callback = conn_lost_callback
-
-    def __repr__(self):
-        """Return the representation."""
-        return '<{}>'.format(self.__class__.__name__)
-
-    def connection_made(self, transport):
-        """Handle created connection."""
-        super().connection_made(transport)
-        if hasattr(self.transport, 'serial'):
-            _LOGGER.info('Connected to %s', self.transport.serial)
-        else:
-            _LOGGER.info('Connected to %s', self.transport)
-
-    def handle_line(self, line):
-        """Handle incoming string data one line at a time."""
-        if not self.gateway.can_log:
-            _LOGGER.debug('Receiving %s', line)
-        self.gateway.add_job(self.gateway.logic, line)
-
-    def connection_lost(self, exc):
-        """Handle lost connection."""
-        _LOGGER.debug('Connection lost with %s', self.transport.serial)
-        if exc:
-            _LOGGER.error(exc)
-            self.transport.serial.close()
-            self.conn_lost_callback()
-        self.transport = None
-
-
-class AsyncMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):
-    """Async serial protocol class."""
-
-    def connection_lost(self, exc):
-        """Handle lost connection."""
-        _LOGGER.debug('Connection lost with %s', self.transport)
-        if exc:
-            _LOGGER.error(exc)
-            self.conn_lost_callback()
-        self.transport = None
+        """Update firwmare of all node_ids in nids."""
+        yield from self.tasks.update_fw(nids, fw_type, fw_ver, fw_path=fw_path)

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -21,12 +21,9 @@ _LOGGER = logging.getLogger(__name__)
 class Gateway:
     """Base implementation for a MySensors Gateway."""
 
-    # pylint: disable=too-many-instance-attributes, unused-argument
+    # pylint: disable=too-many-instance-attributes
 
-    def __init__(
-            self, event_callback=None, persistence=False,
-            persistence_file='mysensors.pickle', protocol_version='1.4',
-            **kwargs):
+    def __init__(self, event_callback=None, protocol_version='1.4'):
         """Set up Gateway."""
         protocol_version = safe_is_version(protocol_version)
         self.const = get_const(protocol_version)
@@ -36,8 +33,6 @@ class Gateway:
         # Copy to allow safe modification.
         self.handlers = dict(handlers)
         self.can_log = False
-        self.persistence = persistence
-        self.persistence_file = persistence_file
         self.protocol_version = protocol_version
         self.sensors = {}
         self.tasks = None
@@ -172,22 +167,25 @@ class Gateway:
 class BaseSyncGateway(Gateway):
     """MySensors base sync gateway."""
 
-    def __init__(self, transport, *args, **kwargs):
+    def __init__(
+            self, transport, *args, persistence=False,
+            persistence_file='mysensors.pickle', **kwargs):
         """Set up gateway."""
         super().__init__(*args, **kwargs)
         self.tasks = SyncTasks(
-            self.const, self.persistence, self.persistence_file, self.sensors,
-            transport)
+            self.const, persistence, persistence_file, self.sensors, transport)
 
 
 class BaseAsyncGateway(Gateway):
     """MySensors base async gateway."""
 
-    def __init__(self, transport, *args, loop=None, **kwargs):
+    def __init__(
+            self, transport, *args, loop=None, persistence=False,
+            persistence_file='mysensors.pickle', **kwargs):
         """Set up gateway."""
         super().__init__(*args, **kwargs)
         self.tasks = AsyncTasks(
-            self.const, self.persistence, self.persistence_file, self.sensors,
+            self.const, persistence, persistence_file, self.sensors,
             transport, loop=loop)
 
     @asyncio.coroutine

--- a/mysensors/cli/helper.py
+++ b/mysensors/cli/helper.py
@@ -25,6 +25,7 @@ def handle_msg(msg):
 
 def run_gateway(gateway):
     """Run a sync gateway."""
+    gateway.start_persistence()
     gateway.start()
     try:
         while True:
@@ -36,6 +37,7 @@ def run_gateway(gateway):
 def run_async_gateway(gateway, stop_task=None):
     """Run an async gateway."""
     try:
+        gateway.tasks.loop.run_until_complete(gateway.start_persistence())
         gateway.tasks.loop.run_until_complete(gateway.start())
         gateway.tasks.loop.run_forever()
     except KeyboardInterrupt:

--- a/mysensors/cli/helper.py
+++ b/mysensors/cli/helper.py
@@ -36,10 +36,10 @@ def run_gateway(gateway):
 def run_async_gateway(gateway, stop_task=None):
     """Run an async gateway."""
     try:
-        gateway.loop.run_until_complete(gateway.start())
-        gateway.loop.run_forever()
+        gateway.tasks.loop.run_until_complete(gateway.start())
+        gateway.tasks.loop.run_forever()
     except KeyboardInterrupt:
-        gateway.loop.run_until_complete(gateway.stop())
+        gateway.tasks.loop.run_until_complete(gateway.stop())
         if stop_task:
-            gateway.loop.run_until_complete(stop_task)
-        gateway.loop.close()
+            gateway.tasks.loop.run_until_complete(stop_task)
+        gateway.tasks.loop.close()

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -1,10 +1,11 @@
 """Implement an MQTT gateway."""
 import asyncio
 import logging
-import threading
 
-from mysensors import BaseAsyncGateway, Gateway, Message, ThreadingGateway
+from mysensors import Gateway, Message
 from .handler import handle_presentation
+from .task import AsyncTasks, SyncTasks
+from .transport import Transport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -12,30 +13,172 @@ _LOGGER = logging.getLogger(__name__)
 class BaseMQTTGateway(Gateway):
     """MySensors MQTT client gateway."""
 
-    # pylint: disable=too-many-arguments, abstract-method
+    def __init__(self, **kwargs):
+        """Set up MQTT client gateway."""
+        super().__init__(**kwargs)
+        self.const.MessageType.presentation.set_handler(
+            self.handlers, self._handle_presentation)
+
+    def init_topics(self):
+        """Set up initial subscription of mysensors topics."""
+        _LOGGER.info('Setting up initial MQTT topic subscription')
+        init_topics = [
+            '/+/+/0/+/+',
+            '/+/+/3/+/+',
+        ]
+        self.tasks.transport.handle_subscription(init_topics)
+        if not self.persistence:
+            return
+        topics = [
+            '/{}/{}/{}/+/+'.format(
+                str(sensor.sensor_id), str(child.id),
+                msg_type) for sensor in self.sensors.values()
+            for child in sensor.children.values()
+            for msg_type in (int(self.const.MessageType.set),
+                             int(self.const.MessageType.req))
+        ]
+        topics.extend([
+            '/{}/+/{}/+/+'.format(
+                str(sensor.sensor_id),
+                int(self.const.MessageType.stream))
+            for sensor in self.sensors.values()])
+        self.tasks.transport.handle_subscription(topics)
+
+    def _handle_presentation(self, msg):
+        """Process a MQTT presentation message."""
+        ret_msg = handle_presentation(msg)
+        if msg.child_id == 255 or ret_msg is None:
+            return
+        # this is a presentation of a child sensor
+        topics = [
+            '/{}/{}/{}/+/+'.format(
+                str(msg.node_id), str(msg.child_id),
+                msg_type)
+            for msg_type in (int(self.const.MessageType.set),
+                             int(self.const.MessageType.req))
+        ]
+        topics.append('/{}/+/{}/+/+'.format(
+            str(msg.node_id),
+            int(self.const.MessageType.stream)))
+        self.tasks.transport.handle_subscription(topics)
+
+    def parse_mqtt_to_message(self, topic, payload, qos):
+        """Parse a MQTT topic and payload.
+
+        Return a mysensors command string.
+        """
+        # pylint: disable=no-self-use
+        topic_levels = topic.split('/')
+        topic_levels = not_prefix = topic_levels[-5:]
+        prefix_end_idx = topic.find('/'.join(not_prefix)) - 1
+        prefix = topic[:prefix_end_idx]
+        if prefix != self.tasks.transport.in_prefix:
+            return None
+        if qos and qos > 0:
+            ack = '1'
+        else:
+            ack = '0'
+        topic_levels[3] = ack
+        topic_levels.append(str(payload))
+        return ';'.join(topic_levels)
+
+    def parse_message_to_mqtt(self, data):
+        """Parse a mysensors command string.
+
+        Return a MQTT topic, payload and qos-level as a tuple.
+        """
+        msg = Message(data, self)
+        payload = str(msg.payload)
+        msg.payload = ''
+        # prefix/node/child/type/ack/subtype : payload
+        return '/{}'.format(msg.encode('/'))[:-2], payload, msg.ack
+
+    def get_gateway_id(self):
+        """Return a unique id for the gateway."""
+        return (
+            self.tasks.transport.in_prefix
+            if self.tasks.transport.in_prefix else None)
+
+
+class MQTTGateway(BaseMQTTGateway):
+    """MySensors MQTT client gateway."""
+
+    # pylint: disable=too-many-arguments
 
     def __init__(
             self, pub_callback, sub_callback, in_prefix='', out_prefix='',
             retain=True, **kwargs):
-        """Set up MQTT client gateway."""
+        """Set up MQTT gateway."""
         super().__init__(**kwargs)
+        transport = MQTTSyncTransport(
+            self, pub_callback, sub_callback, in_prefix=in_prefix,
+            out_prefix=out_prefix, retain=retain)
+        self.tasks = SyncTasks(
+            self.const, self.persistence, self.persistence_file, self.sensors,
+            transport)
+
+
+class AsyncMQTTGateway(BaseMQTTGateway):
+    """MySensors async MQTT client gateway."""
+
+    # pylint: disable=too-many-arguments
+
+    def __init__(
+            self, pub_callback, sub_callback, loop=None, in_prefix='',
+            out_prefix='', retain=True, **kwargs):
+        """Set up MQTT gateway."""
+        super().__init__(**kwargs)
+        transport = MQTTAsyncTransport(
+            self, pub_callback, sub_callback, in_prefix=in_prefix,
+            out_prefix=out_prefix, retain=retain)
+        self.tasks = AsyncTasks(
+            self.const, self.persistence, self.persistence_file, self.sensors,
+            transport, loop=loop)
+
+    @asyncio.coroutine
+    def get_gateway_id(self):
+        """Return a unique id for the gateway."""
+        return super().get_gateway_id()
+
+
+class MQTTTransport(Transport):
+    """MySensors MQTT transport."""
+
+    # pylint: disable=too-many-arguments
+
+    def __init__(
+            self, gateway, pub_callback, sub_callback, in_prefix='',
+            out_prefix='', retain=True):
+        """Set up MQTT client gateway."""
+        super().__init__()
         # Should accept topic, payload, qos, retain.
         self._pub_callback = pub_callback
         # Should accept topic, function callback for receive and qos.
         self._sub_callback = sub_callback
-        self._in_prefix = in_prefix  # prefix for topics gw -> controller
-        self._out_prefix = out_prefix  # prefix for topics controller -> gw
+        self.in_prefix = in_prefix  # prefix for topics gw -> controller
+        self.out_prefix = out_prefix  # prefix for topics controller -> gw
         self._retain = retain  # flag to publish with retain
         # topic structure:
         # prefix/node/child/type/ack/subtype : payload
-        self.const.MessageType.presentation.set_handler(
-            self.handlers, self._handle_presentation)
+        self.gateway = gateway
 
-    def _handle_subscription(self, topics):
+    def connect(self):
+        """Connect to the transport."""
+        raise NotImplementedError
+
+    def disconnect(self):
+        """Disconnect from the transport.
+
+        The MQTT gateway doesn't need to disconnect.
+        """
+        pass
+
+    def handle_subscription(self, topics):
         """Handle subscription of topics."""
         if not isinstance(topics, list):
             topics = [topics]
         for topic in topics:
+            topic = self.in_prefix + topic
             topic_levels = topic.split('/')
             try:
                 qos = int(topic_levels[-2])
@@ -48,100 +191,23 @@ class BaseMQTTGateway(Gateway):
                 _LOGGER.exception(
                     'Subscribe to %s failed: %s', topic, exception)
 
-    def _init_topics(self):
-        """Set up initial subscription of mysensors topics."""
-        _LOGGER.info('Setting up initial MQTT topic subscription')
-        init_topics = [
-            '{}/+/+/0/+/+'.format(self._in_prefix),
-            '{}/+/+/3/+/+'.format(self._in_prefix),
-        ]
-        self._handle_subscription(init_topics)
-        if not self.persistence:
-            return
-        topics = [
-            '{}/{}/{}/{}/+/+'.format(
-                self._in_prefix, str(sensor.sensor_id), str(child.id),
-                msg_type) for sensor in self.sensors.values()
-            for child in sensor.children.values()
-            for msg_type in (int(self.const.MessageType.set),
-                             int(self.const.MessageType.req))
-        ]
-        topics.extend([
-            '{}/{}/+/{}/+/+'.format(
-                self._in_prefix, str(sensor.sensor_id),
-                int(self.const.MessageType.stream))
-            for sensor in self.sensors.values()])
-        self._handle_subscription(topics)
-
-    def _parse_mqtt_to_message(self, topic, payload, qos):
-        """Parse a MQTT topic and payload.
-
-        Return a mysensors command string.
-        """
-        topic_levels = topic.split('/')
-        topic_levels = not_prefix = topic_levels[-5:]
-        prefix_end_idx = topic.find('/'.join(not_prefix)) - 1
-        prefix = topic[:prefix_end_idx]
-        if prefix != self._in_prefix:
-            return None
-        if qos and qos > 0:
-            ack = '1'
-        else:
-            ack = '0'
-        topic_levels[3] = ack
-        topic_levels.append(str(payload))
-        return ';'.join(topic_levels)
-
-    def _parse_message_to_mqtt(self, data):
-        """Parse a mysensors command string.
-
-        Return a MQTT topic, payload and qos-level as a tuple.
-        """
-        msg = Message(data, self)
-        payload = str(msg.payload)
-        msg.payload = ''
-        # prefix/node/child/type/ack/subtype : payload
-        return ('{}/{}'.format(self._out_prefix, msg.encode('/'))[:-2],
-                payload, msg.ack)
-
-    def _handle_presentation(self, msg):
-        """Process a MQTT presentation message."""
-        ret_msg = handle_presentation(msg)
-        if msg.child_id == 255 or ret_msg is None:
-            return
-        # this is a presentation of a child sensor
-        topics = [
-            '{}/{}/{}/{}/+/+'.format(
-                self._in_prefix, str(msg.node_id), str(msg.child_id),
-                msg_type)
-            for msg_type in (int(self.const.MessageType.set),
-                             int(self.const.MessageType.req))
-        ]
-        topics.append('{}/{}/+/{}/+/+'.format(
-            self._in_prefix, str(msg.node_id),
-            int(self.const.MessageType.stream)))
-        self._handle_subscription(topics)
-
-    def get_gateway_id(self):
-        """Return a unique id for the gateway."""
-        return self._in_prefix if self._in_prefix else None
-
     def recv(self, topic, payload, qos):
         """Receive a MQTT message.
 
         Call this method when a message is received from the MQTT broker.
         """
-        data = self._parse_mqtt_to_message(topic, payload, qos)
+        data = self.gateway.parse_mqtt_to_message(topic, payload, qos)
         if data is None:
             return
         _LOGGER.debug('Receiving %s', data)
-        self.add_job(self.logic, data)
+        self.gateway.tasks.add_job(self.gateway.logic, data)
 
     def send(self, message):
         """Publish a command string to the gateway via MQTT."""
         if not message:
             return
-        topic, payload, qos = self._parse_message_to_mqtt(message)
+        topic, payload, qos = self.gateway.parse_message_to_mqtt(message)
+        topic = self.out_prefix + topic
         try:
             _LOGGER.debug('Publishing %s', message.strip())
             self._pub_callback(topic, payload, qos, self._retain)
@@ -149,37 +215,18 @@ class BaseMQTTGateway(Gateway):
             _LOGGER.exception('Publish to %s failed: %s', topic, exception)
 
 
-class MQTTGateway(BaseMQTTGateway, ThreadingGateway):
-    """MySensors MQTT client gateway."""
+class MQTTSyncTransport(MQTTTransport):
+    """TCP sync version of transport class."""
 
-    # pylint: disable=abstract-method
-
-    def send(self, message):
-        """Publish a command string to the gateway via MQTT."""
-        with self.lock:
-            super().send(message)
-
-    def start(self):
-        """Start the connection to a transport."""
-        self._init_topics()
-        poll_thread = threading.Thread(target=self._poll_queue)
-        poll_thread.start()
-
-    def stop(self):
-        """Stop the gateway."""
-        _LOGGER.info('Stopping gateway')
-        super().stop()
-
-
-class AsyncMQTTGateway(BaseMQTTGateway, BaseAsyncGateway):
-    """MySensors async MQTT client gateway."""
-
-    @asyncio.coroutine
-    def _connect(self):
+    def connect(self):
         """Connect to the transport."""
-        self._init_topics()
+        self.gateway.init_topics()
+
+
+class MQTTAsyncTransport(MQTTTransport):
+    """TCP async version of transport class."""
 
     @asyncio.coroutine
-    def get_gateway_id(self):
-        """Return a unique id for the gateway."""
-        return super().get_gateway_id()
+    def connect(self):
+        """Connect to the transport."""
+        self.gateway.init_topics()

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -27,7 +27,7 @@ class BaseMQTTGateway(Gateway):
             '/+/+/3/+/+',
         ]
         self.tasks.transport.handle_subscription(init_topics)
-        if not self.persistence:
+        if not self.tasks.persistence:
             return
         topics = [
             '/{}/{}/{}/+/+'.format(
@@ -107,14 +107,15 @@ class MQTTGateway(BaseMQTTGateway):
 
     def __init__(
             self, pub_callback, sub_callback, in_prefix='', out_prefix='',
-            retain=True, **kwargs):
+            retain=True, persistence=False,
+            persistence_file='mysensors.pickle', **kwargs):
         """Set up MQTT gateway."""
         super().__init__(**kwargs)
         transport = MQTTSyncTransport(
             self, pub_callback, sub_callback, in_prefix=in_prefix,
             out_prefix=out_prefix, retain=retain)
         self.tasks = SyncTasks(
-            self.const, self.persistence, self.persistence_file, self.sensors,
+            self.const, persistence, persistence_file, self.sensors,
             transport)
 
 
@@ -125,14 +126,15 @@ class AsyncMQTTGateway(BaseMQTTGateway):
 
     def __init__(
             self, pub_callback, sub_callback, loop=None, in_prefix='',
-            out_prefix='', retain=True, **kwargs):
+            out_prefix='', retain=True, persistence=False,
+            persistence_file='mysensors.pickle', **kwargs):
         """Set up MQTT gateway."""
         super().__init__(**kwargs)
         transport = MQTTAsyncTransport(
             self, pub_callback, sub_callback, in_prefix=in_prefix,
             out_prefix=out_prefix, retain=retain)
         self.tasks = AsyncTasks(
-            self.const, self.persistence, self.persistence_file, self.sensors,
+            self.const, persistence, persistence_file, self.sensors,
             transport, loop=loop)
 
     @asyncio.coroutine

--- a/mysensors/gateway_serial.py
+++ b/mysensors/gateway_serial.py
@@ -1,7 +1,6 @@
 """Implement a serial gateway."""
 import asyncio
 import logging
-import threading
 import time
 
 import serial
@@ -9,17 +8,14 @@ import serial.threaded
 import serial.tools.list_ports
 import serial_asyncio
 
-from mysensors import (
-    BaseAsyncGateway, BaseMySensorsProtocol, BaseTransportGateway,
-    ThreadingGateway)
+from mysensors import BaseSyncGateway, BaseAsyncGateway, Gateway
+from .transport import AsyncTransport, SyncTransport
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class BaseSerialGateway(BaseTransportGateway):
+class BaseSerialGateway(Gateway):
     """MySensors base serial gateway."""
-
-    # pylint: disable=abstract-method
 
     def __init__(self, port, baud=115200, **kwargs):
         """Set up base serial gateway."""
@@ -33,23 +29,27 @@ class BaseSerialGateway(BaseTransportGateway):
         return info.serial_number if info is not None else None
 
 
-class SerialGateway(BaseSerialGateway, ThreadingGateway):
+class SerialGateway(BaseSyncGateway, BaseSerialGateway):
     """MySensors serial gateway."""
 
     def __init__(self, *args, **kwargs):
         """Set up serial gateway."""
-        super().__init__(*args, **kwargs)
-        self.protocol = BaseMySensorsProtocol(self, self.start)
+        transport = SerialSyncTransport(self, **kwargs)
+        super().__init__(transport, *args, **kwargs)
+
+
+class SerialSyncTransport(SyncTransport):
+    """Serial sync version of transport class."""
 
     def _connect(self):
         """Connect to the serial port. This should be run in a new thread."""
         while self.protocol:
-            _LOGGER.info('Trying to connect to %s', self.port)
+            _LOGGER.info('Trying to connect to %s', self.gateway.port)
             try:
                 ser = serial.serial_for_url(
-                    self.port, self.baud, timeout=self.timeout)
+                    self.gateway.port, self.gateway.baud, timeout=self.timeout)
             except serial.SerialException:
-                _LOGGER.error('Unable to connect to %s', self.port)
+                _LOGGER.error('Unable to connect to %s', self.gateway.port)
                 _LOGGER.info(
                     'Waiting %s secs before trying to connect again',
                     self.reconnect_timeout)
@@ -58,46 +58,47 @@ class SerialGateway(BaseSerialGateway, ThreadingGateway):
                 transport = serial.threaded.ReaderThread(
                     ser, lambda: self.protocol)
                 transport.daemon = False
-                poll_thread = threading.Thread(target=self._poll_queue)
-                self._stop_event.clear()
-                poll_thread.start()
                 transport.start()
                 transport.connect()
                 return
 
-    def stop(self):
-        """Stop the gateway."""
-        _LOGGER.info('Stopping gateway')
-        self._disconnect()
-        super().stop()
 
-
-class AsyncSerialGateway(BaseSerialGateway, BaseAsyncGateway):
+class AsyncSerialGateway(BaseAsyncGateway, BaseSerialGateway):
     """MySensors async serial gateway."""
 
+    def __init__(self, *args, loop=None, **kwargs):
+        """Set up serial gateway."""
+        transport = SerialAsyncTransport(self, loop=loop, **kwargs)
+        super().__init__(transport, *args, loop=loop, **kwargs)
+
     @asyncio.coroutine
-    def _connect(self):
+    def get_gateway_id(self):
+        """Return a unique id for the gateway."""
+        serial_number = yield from self.tasks.loop.run_in_executor(
+            None, super().get_gateway_id)
+        return serial_number
+
+
+class SerialAsyncTransport(AsyncTransport):
+    """Serial async version of transport class."""
+
+    @asyncio.coroutine
+    def connect(self):
         """Connect to the serial port."""
         try:
             while True:
-                _LOGGER.info('Trying to connect to %s', self.port)
+                _LOGGER.info('Trying to connect to %s', self.gateway.port)
                 try:
                     yield from serial_asyncio.create_serial_connection(
-                        self.loop, lambda: self.protocol, self.port, self.baud)
+                        self.loop, lambda: self.protocol,
+                        self.gateway.port, self.gateway.baud)
                     return
                 except serial.SerialException:
-                    _LOGGER.error('Unable to connect to %s', self.port)
+                    _LOGGER.error('Unable to connect to %s', self.gateway.port)
                     _LOGGER.info(
                         'Waiting %s secs before trying to connect again',
                         self.reconnect_timeout)
                     yield from asyncio.sleep(
                         self.reconnect_timeout, loop=self.loop)
         except asyncio.CancelledError:
-            _LOGGER.debug('Connect attempt to %s cancelled', self.port)
-
-    @asyncio.coroutine
-    def get_gateway_id(self):
-        """Return a unique id for the gateway."""
-        serial_number = yield from self.loop.run_in_executor(
-            None, super().get_gateway_id)
-        return serial_number
+            _LOGGER.debug('Connect attempt to %s cancelled', self.gateway.port)

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -68,47 +68,45 @@ class TCPGateway(BaseSyncGateway, BaseTCPGateway):
 
     def __init__(self, *args, **kwargs):
         """Set up TCP gateway."""
-        transport = TCPSyncTransport(self, **kwargs)
+        transport = SyncTransport(self, sync_connect, **kwargs)
         super().__init__(transport, *args, **kwargs)
 
 
-class TCPSyncTransport(SyncTransport):
-    """TCP sync version of transport class."""
-
-    def _connect(self):
-        """Connect to socket. This should be run in a new thread."""
-        while self.protocol:
+def sync_connect(transport):
+    """Connect to socket. This should be run in a new thread."""
+    while transport.protocol:
+        _LOGGER.info(
+            'Trying to connect to %s',
+            transport.gateway.server_address)
+        try:
+            sock = socket.create_connection(
+                transport.gateway.server_address,
+                transport.reconnect_timeout)
+        except socket.timeout:
+            _LOGGER.error(
+                'Connecting to socket timed out for %s',
+                transport.gateway.server_address)
             _LOGGER.info(
-                'Trying to connect to %s', self.gateway.server_address)
-            try:
-                sock = socket.create_connection(
-                    self.gateway.server_address,
-                    self.reconnect_timeout)
-            except socket.timeout:
-                _LOGGER.error(
-                    'Connecting to socket timed out for %s',
-                    self.gateway.server_address)
-                _LOGGER.info(
-                    'Waiting %s secs before trying to connect again',
-                    self.reconnect_timeout)
-                time.sleep(self.reconnect_timeout)
-            except OSError:
-                _LOGGER.error(
-                    'Failed to connect to socket at %s',
-                    self.gateway.server_address)
-                _LOGGER.info(
-                    'Waiting %s secs before trying to connect again',
-                    self.reconnect_timeout)
-                time.sleep(self.reconnect_timeout)
-            else:
-                self.gateway.tcp_check_timer = time.time()
-                self.gateway.tcp_disconnect_timer = time.time()
-                transport = TCPTransport(
-                    sock, lambda: self.protocol,
-                    self.gateway.check_connection)
-                transport.start()
-                transport.connect()
-                return
+                'Waiting %s secs before trying to connect again',
+                transport.reconnect_timeout)
+            time.sleep(transport.reconnect_timeout)
+        except OSError:
+            _LOGGER.error(
+                'Failed to connect to socket at %s',
+                transport.gateway.server_address)
+            _LOGGER.info(
+                'Waiting %s secs before trying to connect again',
+                transport.reconnect_timeout)
+            time.sleep(transport.reconnect_timeout)
+        else:
+            transport.gateway.tcp_check_timer = time.time()
+            transport.gateway.tcp_disconnect_timer = time.time()
+            tcp_transport = TCPTransport(
+                sock, lambda: transport.protocol,
+                transport.gateway.check_connection)
+            tcp_transport.start()
+            tcp_transport.connect()
+            return
 
 
 class AsyncTCPGateway(BaseAsyncGateway, BaseTCPGateway):
@@ -118,8 +116,8 @@ class AsyncTCPGateway(BaseAsyncGateway, BaseTCPGateway):
         """Set up TCP gateway."""
         self.cancel_check_conn = None
         protocol = AsyncTCPMySensorsProtocol
-        transport = TCPAsyncTransport(
-            self, loop=loop, protocol=protocol, **kwargs)
+        transport = AsyncTransport(
+            self, async_connect, loop=loop, protocol=protocol, **kwargs)
         super().__init__(transport, *args, loop=loop, **kwargs)
 
     def check_connection(self):
@@ -144,48 +142,46 @@ class AsyncTCPGateway(BaseAsyncGateway, BaseTCPGateway):
         return mac
 
 
-class TCPAsyncTransport(AsyncTransport):
-    """TCP async version of transport class."""
-
-    @asyncio.coroutine
-    def connect(self):
-        """Connect to the socket."""
-        try:
-            while True:
+@asyncio.coroutine
+def async_connect(transport):
+    """Connect to the socket."""
+    try:
+        while True:
+            _LOGGER.info(
+                'Trying to connect to %s', transport.gateway.server_address)
+            try:
+                yield from asyncio.wait_for(
+                    transport.loop.create_connection(
+                        lambda: transport.protocol,
+                        *transport.gateway.server_address),
+                    transport.reconnect_timeout, loop=transport.loop)
+                transport.gateway.tcp_check_timer = time.time()
+                transport.gateway.tcp_disconnect_timer = time.time()
+                transport.gateway.check_connection()
+                return
+            except asyncio.TimeoutError:
+                _LOGGER.error(
+                    'Connecting to socket timed out for %s',
+                    transport.gateway.server_address)
                 _LOGGER.info(
-                    'Trying to connect to %s', self.gateway.server_address)
-                try:
-                    yield from asyncio.wait_for(
-                        self.loop.create_connection(
-                            lambda: self.protocol,
-                            *self.gateway.server_address),
-                        self.reconnect_timeout, loop=self.loop)
-                    self.gateway.tcp_check_timer = time.time()
-                    self.gateway.tcp_disconnect_timer = time.time()
-                    self.gateway.check_connection()
-                    return
-                except asyncio.TimeoutError:
-                    _LOGGER.error(
-                        'Connecting to socket timed out for %s',
-                        self.gateway.server_address)
-                    _LOGGER.info(
-                        'Waiting %s secs before trying to connect again',
-                        self.reconnect_timeout)
-                    yield from asyncio.sleep(
-                        self.reconnect_timeout, loop=self.loop)
-                except OSError:
-                    _LOGGER.error(
-                        'Failed to connect to socket at %s',
-                        self.gateway.server_address)
-                    _LOGGER.info(
-                        'Waiting %s secs before trying to connect again',
-                        self.reconnect_timeout)
-                    yield from asyncio.sleep(
-                        self.reconnect_timeout,
-                        loop=self.loop)
-        except asyncio.CancelledError:
-            _LOGGER.debug(
-                'Connect attempt to %s cancelled', self.gateway.server_address)
+                    'Waiting %s secs before trying to connect again',
+                    transport.reconnect_timeout)
+                yield from asyncio.sleep(
+                    transport.reconnect_timeout, loop=transport.loop)
+            except OSError:
+                _LOGGER.error(
+                    'Failed to connect to socket at %s',
+                    transport.gateway.server_address)
+                _LOGGER.info(
+                    'Waiting %s secs before trying to connect again',
+                    transport.reconnect_timeout)
+                yield from asyncio.sleep(
+                    transport.reconnect_timeout,
+                    loop=transport.loop)
+    except asyncio.CancelledError:
+        _LOGGER.debug(
+            'Connect attempt to %s cancelled',
+            transport.gateway.server_address)
 
 
 class AsyncTCPMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -34,8 +34,8 @@ class BaseTCPGateway(Gateway):
             self.tcp_disconnect_timer = time.time()
             raise OSError('No response from {}. Disconnecting'.format(
                 self.server_address))
-        if ((self.tcp_check_timer + self.tasks.transport.reconnect_timeout) >=
-                time.time()):
+        if ((self.tcp_check_timer + self.tasks.transport.reconnect_timeout)
+                >= time.time()):
             return
         msg = Message().modify(
             child_id=255, type=self.const.MessageType.internal,

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -2,6 +2,7 @@
 import calendar
 import logging
 import time
+
 from .const import SYSTEM_CHILD_ID
 from .sensor import ChildSensor
 from .util import Registry
@@ -14,7 +15,7 @@ HANDLERS = Registry()
 def handle_smartsleep(msg):
     """Process a message before going back to smartsleep."""
     while msg.gateway.sensors[msg.node_id].queue:
-        msg.gateway.add_job(
+        msg.gateway.tasks.add_job(
             str, msg.gateway.sensors[msg.node_id].queue.popleft())
     for child in msg.gateway.sensors[msg.node_id].children.values():
         new_child = msg.gateway.sensors[msg.node_id].new_state.get(
@@ -23,7 +24,7 @@ def handle_smartsleep(msg):
         for value_type, value in child.values.items():
             new_value = new_child.values.get(value_type)
             if new_value is not None and new_value != value:
-                msg.gateway.add_job(
+                msg.gateway.tasks.add_job(
                     msg.gateway.sensors[msg.node_id].set_child_value,
                     child.id, value_type, new_value)
 
@@ -118,13 +119,13 @@ def handle_stream(msg):
 @HANDLERS.register('ST_FIRMWARE_CONFIG_REQUEST')
 def handle_firmware_config_request(msg):
     """Process a firmware config request message."""
-    return msg.gateway.ota.respond_fw_config(msg)
+    return msg.gateway.tasks.ota.respond_fw_config(msg)
 
 
 @HANDLERS.register('ST_FIRMWARE_REQUEST')
 def handle_firmware_request(msg):
     """Process a firmware request message."""
-    return msg.gateway.ota.respond_fw(msg)
+    return msg.gateway.tasks.ota.respond_fw(msg)
 
 
 @HANDLERS.register('I_ID_REQUEST')

--- a/mysensors/persistence.py
+++ b/mysensors/persistence.py
@@ -16,11 +16,11 @@ class Persistence:
             self, sensors, schedule_factory,
             persistence_file='mysensors.pickle'):
         """Set up Persistence instance."""
+        self._sensors = sensors
+        self.need_save = True
         self.persistence_file = persistence_file
         self.persistence_bak = '{}.bak'.format(self.persistence_file)
         self.schedule_save_sensors = schedule_factory(self.save_sensors)
-        self._sensors = sensors
-        self.need_save = True
 
     def _save_pickle(self, filename):
         """Save sensors to pickle file."""

--- a/mysensors/task.py
+++ b/mysensors/task.py
@@ -1,0 +1,233 @@
+"""Handle sync and async tasks."""
+import asyncio
+from collections import deque
+from functools import partial
+import logging
+import threading
+import time
+from timeit import default_timer as timer
+
+from .ota import OTAFirmware, load_fw
+from .persistence import Persistence
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Tasks:
+    """Handle gateway tasks.
+
+    I/O is allowed in this class. The Task class should host methods that need
+    to do I/O or perform tasks that are not related to the gateway transport
+    type.
+
+    The transport attribute should hold an instance of the Transport class.
+    """
+
+    # pylint: disable=too-many-arguments
+
+    def __init__(
+            self, const, persistence, persistence_file, sensors, transport):
+        """Set up Tasks."""
+        self.queue = deque()
+        self.ota = OTAFirmware(sensors, const)
+        if persistence:
+            self.persistence = Persistence(
+                sensors, self._schedule_factory,
+                persistence_file=persistence_file)
+        else:
+            self.persistence = None
+        self.transport = transport
+
+    def _schedule_factory(self, save_sensors):
+        """Return function to schedule saving sensors."""
+        raise NotImplementedError
+
+    def add_job(self, func, *args):
+        """Add a job that should return a reply to be sent."""
+        raise NotImplementedError
+
+    def run_job(self, job=None):
+        """Run a job, either passed in or from the queue.
+
+        A job is a tuple of function and optional args. Keyword arguments
+        can be passed via use of functools.partial. The job should return a
+        string that should be sent by the gateway protocol. The function will
+        be called with the arguments and the result will be returned.
+        """
+        if job is None:
+            if not self.queue:
+                return None
+            job = self.queue.popleft()
+        start = timer()
+        func, args = job
+        reply = func(*args)
+        end = timer()
+        if end - start > 0.1:
+            _LOGGER.debug(
+                'Handle queue with call %s(%s) took %.3f seconds',
+                func, args, end - start)
+        return reply
+
+    def start(self):
+        """Start the gateway and task allow tasks to be scheduled."""
+        raise NotImplementedError
+
+    def stop(self):
+        """Stop the gateway and stop allowing tasks for the scheduler."""
+        raise NotImplementedError
+
+    def start_persistence(self):
+        """Start persistence."""
+        raise NotImplementedError
+
+    def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
+        """Update firwmare."""
+        raise NotImplementedError
+
+
+class SyncTasks(Tasks):
+    """Sync version of tasks class."""
+
+    def __init__(self, *args, **kwargs):
+        """Set up Tasks."""
+        super().__init__(*args, **kwargs)
+        self._cancel_save = None
+        self._stop_event = threading.Event()
+
+    def add_job(self, func, *args):
+        """Add a job that should return a reply to be sent.
+
+        A job is a tuple of function and optional args. Keyword arguments
+        can be passed via use of functools.partial. The job should return a
+        string that should be sent by the gateway protocol.
+        """
+        self.queue.append((func, args))
+
+    def start(self):
+        """Start the connection to a transport."""
+        self.transport.connect()
+        poll_thread = threading.Thread(target=self._poll_queue)
+        poll_thread.start()
+
+    def _poll_queue(self):
+        """Poll the queue for work."""
+        while not self._stop_event.is_set():
+            reply = self.run_job()
+            self.transport.send(reply)
+            if self.queue:
+                continue
+            time.sleep(0.02)
+
+    def _schedule_factory(self, save_sensors):
+        """Return function to schedule saving sensors."""
+        def schedule_save():
+            """Save sensors and schedule a new save."""
+            save_sensors()
+            scheduler = threading.Timer(10.0, schedule_save)
+            scheduler.start()
+            self._cancel_save = scheduler.cancel
+        return schedule_save
+
+    def start_persistence(self):
+        """Load persistence file and schedule saving of persistence file."""
+        if not self.persistence:
+            return
+        self.persistence.safe_load_sensors()
+        self._cancel_save = self.persistence.schedule_save_sensors()
+
+    def stop(self):
+        """Stop the background thread."""
+        _LOGGER.info('Stopping gateway')
+        self.transport.disconnect()
+        self._stop_event.set()
+        if not self.persistence:
+            return
+        if self._cancel_save is not None:
+            self._cancel_save()
+            self._cancel_save = None
+        self.persistence.save_sensors()
+
+    def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
+        """Update firwmare of all node_ids in nids."""
+        fw_bin = None
+        if fw_path:
+            fw_bin = load_fw(fw_path)
+            if not fw_bin:
+                return
+        self.ota.make_update(nids, fw_type, fw_ver, fw_bin)
+
+
+class AsyncTasks(Tasks):
+    """Async version of tasks class."""
+
+    def __init__(self, *args, loop=None, **kwargs):
+        """Set up Tasks."""
+        super().__init__(*args, **kwargs)
+        self.loop = loop or asyncio.get_event_loop()
+        self._cancel_save = None
+
+    @asyncio.coroutine
+    def start(self):
+        """Start the connection to a transport."""
+        yield from self.transport.connect()
+
+    @asyncio.coroutine
+    def stop(self):
+        """Stop the gateway."""
+        _LOGGER.info('Stopping gateway')
+        self.transport.disconnect()
+        if self.transport.connect_task and \
+                not self.transport.connect_task.cancelled():
+            self.transport.connect_task.cancel()
+            self.transport.connect_task = None
+        if not self.persistence:
+            return
+        if self._cancel_save is not None:
+            self._cancel_save()
+            self._cancel_save = None
+        yield from self.loop.run_in_executor(
+            None, self.persistence.save_sensors)
+
+    def add_job(self, func, *args):
+        """Add a job that should return a reply to be sent.
+
+        A job is a tuple of function and optional args. Keyword arguments
+        can be passed via use of functools.partial. The job should return a
+        string that should be sent by the gateway protocol.
+
+        The async version of this method will send the reply directly.
+        """
+        job = func, args
+        reply = self.run_job(job)
+        self.transport.send(reply)
+
+    def _schedule_factory(self, save_sensors):
+        """Return function to schedule saving sensors."""
+        @asyncio.coroutine
+        def schedule_save():
+            """Save sensors and schedule a new save."""
+            yield from self.loop.run_in_executor(None, save_sensors)
+            callback = partial(self.loop.create_task, schedule_save())
+            task = self.loop.call_later(10.0, callback)
+            self._cancel_save = task.cancel
+        return schedule_save
+
+    @asyncio.coroutine
+    def start_persistence(self):
+        """Load persistence file and schedule saving of persistence file."""
+        if not self.persistence:
+            return
+        yield from self.loop.run_in_executor(
+            None, self.persistence.safe_load_sensors)
+        yield from self.persistence.schedule_save_sensors()
+
+    @asyncio.coroutine
+    def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
+        """Start update firwmare of all node_ids in nids in executor."""
+        fw_bin = None
+        if fw_path:
+            fw_bin = yield from self.loop.run_in_executor(
+                None, load_fw, fw_path)
+            if not fw_bin:
+                return
+        self.ota.make_update(nids, fw_type, fw_ver, fw_bin)

--- a/mysensors/transport.py
+++ b/mysensors/transport.py
@@ -1,0 +1,153 @@
+"""Organize MySensors transports."""
+import asyncio
+import logging
+import threading
+
+import serial.threaded
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Transport:
+    """Handle gateway transport.
+
+    I/O is allowed in this class. This class should host methods that
+    are related to the gateway transport type.
+    """
+
+    # pylint: disable=unused-argument
+
+    def __init__(self, timeout=1.0, reconnect_timeout=10.0, **kwargs):
+        """Set up transport."""
+        self.can_log = False
+        self.protocol = None
+        self.reconnect_timeout = reconnect_timeout
+        self.timeout = timeout
+
+    def connect(self):
+        """Connect to the transport."""
+        raise NotImplementedError
+
+    def disconnect(self):
+        """Disconnect from the transport."""
+        if not self.protocol or not self.protocol.transport:
+            self.protocol = None  # Make sure protocol is None
+            return
+        _LOGGER.info('Disconnecting from gateway')
+        self.protocol.transport.close()
+        self.protocol = None
+
+    def send(self, message):
+        """Write a message to the gateway."""
+        if not message or not self.protocol or not self.protocol.transport:
+            return
+        if not self.can_log:
+            _LOGGER.debug('Sending %s', message.strip())
+        try:
+            self.protocol.transport.write(message.encode())
+        except OSError as exc:
+            _LOGGER.error(
+                'Failed writing to transport %s: %s',
+                self.protocol.transport, exc)
+            self.protocol.transport.close()
+            self.protocol.conn_lost_callback()
+
+
+class SyncTransport(Transport):
+    """Sync version of transport class."""
+
+    def __init__(self, gateway, **kwargs):
+        """Set up transport."""
+        super().__init__(**kwargs)
+        self._lock = threading.Lock()
+        self.gateway = gateway
+        self.protocol = BaseMySensorsProtocol(gateway, self.connect)
+
+    def _connect(self):
+        """Connect to the transport."""
+        raise NotImplementedError
+
+    def connect(self):
+        """Connect to the transport."""
+        connect_thread = threading.Thread(target=self._connect)
+        connect_thread.start()
+
+    def send(self, message):
+        """Write a message to the gateway."""
+        with self._lock:
+            super().send(message)
+
+
+class AsyncTransport(Transport):
+    """Async version of transport class."""
+
+    def __init__(self, gateway, loop=None, protocol=None, **kwargs):
+        """Set up transport."""
+        super().__init__(**kwargs)
+        self.gateway = gateway
+        self.loop = loop or asyncio.get_event_loop()
+        self.connect_task = None
+
+        def conn_lost():
+            """Handle connection_lost in protocol class."""
+            self.connect_task = self.loop.create_task(self.connect())
+
+        if not protocol:
+            protocol = AsyncMySensorsProtocol
+        self.protocol = protocol(gateway, conn_lost)
+
+    @asyncio.coroutine
+    def connect(self):
+        """Connect to the transport."""
+        raise NotImplementedError
+
+
+class BaseMySensorsProtocol(serial.threaded.LineReader):
+    """MySensors base protocol class."""
+
+    TERMINATOR = b'\n'
+
+    def __init__(self, gateway, conn_lost_callback):
+        """Set up base protocol."""
+        super().__init__()
+        self.gateway = gateway
+        self.conn_lost_callback = conn_lost_callback
+
+    def __repr__(self):
+        """Return the representation."""
+        return '<{}>'.format(self.__class__.__name__)
+
+    def connection_made(self, transport):
+        """Handle created connection."""
+        super().connection_made(transport)
+        if hasattr(self.transport, 'serial'):
+            _LOGGER.info('Connected to %s', self.transport.serial)
+        else:
+            _LOGGER.info('Connected to %s', self.transport)
+
+    def handle_line(self, line):
+        """Handle incoming string data one line at a time."""
+        if not self.gateway.tasks.transport.can_log:
+            _LOGGER.debug('Receiving %s', line)
+        self.gateway.tasks.add_job(self.gateway.logic, line)
+
+    def connection_lost(self, exc):
+        """Handle lost connection."""
+        _LOGGER.debug('Connection lost with %s', self.transport.serial)
+        if exc:
+            _LOGGER.error(exc)
+            self.transport.serial.close()
+            self.conn_lost_callback()
+        self.transport = None
+
+
+class AsyncMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):
+    """Async serial protocol class."""
+
+    def connection_lost(self, exc):
+        """Handle lost connection."""
+        _LOGGER.debug('Connection lost with %s', self.transport)
+        if exc:
+            _LOGGER.error(exc)
+            self.conn_lost_callback()
+        self.transport = None

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -188,8 +188,7 @@ def get_gateway(**kwargs):
     """Return a gateway instance."""
     _gateway = Gateway(**kwargs)
     _gateway.tasks = SyncTasks(
-        _gateway.const, _gateway.persistence, _gateway.persistence_file,
-        _gateway.sensors, mock.MagicMock())
+        _gateway.const, False, None, _gateway.sensors, mock.MagicMock())
     return _gateway
 
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,9 +1,12 @@
 """Test mysensors messages."""
+from unittest import mock
+
 import pytest
 import voluptuous as vol
 
 from mysensors import Gateway, Message, get_const, Sensor
 from mysensors.const_14 import Internal, MessageType
+from mysensors.task import SyncTasks
 
 PRES_FIXTURES_14 = {
     'S_DOOR': 'Front Door',
@@ -182,8 +185,12 @@ INTERNAL_FIXTURES_22.update({
 
 
 def get_gateway(**kwargs):
-    """Return a gateway."""
-    return Gateway(**kwargs)
+    """Return a gateway instance."""
+    _gateway = Gateway(**kwargs)
+    _gateway.tasks = SyncTasks(
+        _gateway.const, _gateway.persistence, _gateway.persistence_file,
+        _gateway.sensors, mock.MagicMock())
+    return _gateway
 
 
 def get_message(message_data=None):

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -18,8 +18,7 @@ def gateway(request):
     """Return gateway instance."""
     _gateway = Gateway(protocol_version=request.param)
     _gateway.tasks = SyncTasks(
-        _gateway.const, _gateway.persistence, _gateway.persistence_file,
-        _gateway.sensors, None)
+        _gateway.const, False, None, _gateway.sensors, None)
     return _gateway
 
 
@@ -27,8 +26,7 @@ def get_gateway(**kwargs):
     """Return a gateway instance."""
     _gateway = Gateway(**kwargs)
     _gateway.tasks = SyncTasks(
-        _gateway.const, _gateway.persistence, _gateway.persistence_file,
-        _gateway.sensors, None)
+        _gateway.const, False, None, _gateway.sensors, None)
     return _gateway
 
 

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -6,6 +6,7 @@ from unittest import TestCase, main
 
 from mysensors import Gateway, Sensor
 from mysensors.ota import FIRMWARE_BLOCK_SIZE, load_fw
+from mysensors.task import SyncTasks
 
 FW_TYPE = 1
 FW_VER = 1
@@ -26,6 +27,9 @@ class TestOTA(TestCase):
     def setUp(self):
         """Set up gateway."""
         self.gateway = Gateway()
+        self.gateway.tasks = SyncTasks(
+            self.gateway.const, self.gateway.persistence,
+            self.gateway.persistence_file, self.gateway.sensors, None)
 
     def _add_sensor(self, sensorid):
         """Add sensor node. Return sensor node instance."""
@@ -42,7 +46,7 @@ class TestOTA(TestCase):
                 hex_file_str.encode('utf-8'))
             file_handle.flush()
             fw_bin = load_fw(file_handle.name)
-            self.gateway.ota.make_update(
+            self.gateway.tasks.ota.make_update(
                 [sensor.sensor_id for sensor in sensors], FW_TYPE, FW_VER,
                 fw_bin)
 
@@ -55,7 +59,7 @@ class TestOTA(TestCase):
     def test_no_fw(self):
         """Test firmware update with no firmware loaded."""
         sensor = self._add_sensor(1)
-        self.gateway.ota.make_update(
+        self.gateway.tasks.ota.make_update(
             sensor.sensor_id, FW_TYPE, FW_VER)
         ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
         self.assertEqual(ret, None)
@@ -63,7 +67,7 @@ class TestOTA(TestCase):
     def test_bad_fw_type_or_version(self):
         """Test firmware update with bad firmware type or version."""
         sensor = self._add_sensor(1)
-        self.gateway.ota.make_update(
+        self.gateway.tasks.ota.make_update(
             sensor.sensor_id, 'a', 'b')
         ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
         self.assertEqual(ret, None)
@@ -75,7 +79,7 @@ class TestOTA(TestCase):
                 HEX_FILE_STR.encode('utf-8'))
             file_handle.flush()
             fw_bin = load_fw(file_handle.name)
-            self.gateway.ota.make_update(1, FW_TYPE, FW_VER, fw_bin)
+            self.gateway.tasks.ota.make_update(1, FW_TYPE, FW_VER, fw_bin)
         ret = self.gateway.logic('1;255;4;0;0;01000200B00626E80300\n')
         self.assertEqual(ret, None)
 
@@ -132,7 +136,7 @@ class TestOTA(TestCase):
                 HEX_FILE_STR.encode('utf-8'))
             file_handle.flush()
             fw_bin = load_fw(file_handle.name)
-            self.gateway.ota.make_update(1, FW_TYPE, FW_VER, fw_bin)
+            self.gateway.tasks.ota.make_update(1, FW_TYPE, FW_VER, fw_bin)
         payload = binascii.hexlify(
             struct.pack('<3H', FW_TYPE, FW_VER, block - 1)).decode('utf-8')
         ret = self.gateway.logic('1;255;4;0;2;{}\n'.format(payload))

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -28,8 +28,7 @@ class TestOTA(TestCase):
         """Set up gateway."""
         self.gateway = Gateway()
         self.gateway.tasks = SyncTasks(
-            self.gateway.const, self.gateway.persistence,
-            self.gateway.persistence_file, self.gateway.sensors, None)
+            self.gateway.const, False, None, self.gateway.sensors, None)
 
     def _add_sensor(self, sensorid):
         """Add sensor node. Return sensor node instance."""

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -181,23 +181,6 @@ def test_persistence_upgrade(
     assert gateway.sensors[1].children[0].type == sensor.children[0].type
 
 
-@mock.patch('mysensors.persistence.Persistence.save_sensors')
-def test_schedule_save_sensors(mock_save, gateway):
-    """Test schedule save sensors."""
-    mock_schedule_save = mock.MagicMock()
-    mock_schedule_factory = mock.MagicMock()
-    mock_schedule_factory.return_value = mock_schedule_save
-
-    gateway.persistence = Persistence(gateway.sensors, mock_schedule_factory)
-
-    assert mock_schedule_factory.call_count == 1
-    assert mock_schedule_factory.call_args == mock.call(mock_save)
-
-    gateway.persistence.schedule_save_sensors()
-
-    assert mock_schedule_save.call_count == 1
-
-
 class MySensorsJSONEncoderTestUpgrade(MySensorsJSONEncoder):
     """JSON encoder used for testing upgrade with missing attributes."""
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -9,8 +9,8 @@ def get_gateway(**kwargs):
     """Return a gateway instance."""
     _gateway = Gateway(**kwargs)
     _gateway.tasks = SyncTasks(
-        _gateway.const, _gateway.persistence, _gateway.persistence_file,
-        _gateway.sensors, mock.MagicMock())
+        _gateway.const, True, 'mysensors.pickle', _gateway.sensors,
+        mock.MagicMock())
     return _gateway
 
 
@@ -21,7 +21,7 @@ def test_threading_persistence(mock_timer_class, mock_save_sensors):
     mock_timer_1 = mock.MagicMock()
     mock_timer_2 = mock.MagicMock()
     mock_timer_class.side_effect = [mock_timer_1, mock_timer_2]
-    gateway = get_gateway(persistence=True)
+    gateway = get_gateway()
     gateway.tasks.persistence.schedule_save_sensors()
     assert mock_save_sensors.call_count == 1
     assert mock_timer_class.call_count == 1

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,36 @@
+"""Test task module."""
+from unittest import mock
+
+from mysensors import Gateway
+from mysensors.task import SyncTasks
+
+
+def get_gateway(**kwargs):
+    """Return a gateway instance."""
+    _gateway = Gateway(**kwargs)
+    _gateway.tasks = SyncTasks(
+        _gateway.const, _gateway.persistence, _gateway.persistence_file,
+        _gateway.sensors, mock.MagicMock())
+    return _gateway
+
+
+@mock.patch('mysensors.persistence.Persistence.save_sensors')
+@mock.patch('mysensors.task.threading.Timer')
+def test_threading_persistence(mock_timer_class, mock_save_sensors):
+    """Test schedule persistence on threading gateway."""
+    mock_timer_1 = mock.MagicMock()
+    mock_timer_2 = mock.MagicMock()
+    mock_timer_class.side_effect = [mock_timer_1, mock_timer_2]
+    gateway = get_gateway(persistence=True)
+    gateway.tasks.persistence.schedule_save_sensors()
+    assert mock_save_sensors.call_count == 1
+    assert mock_timer_class.call_count == 1
+    assert mock_timer_1.start.call_count == 1
+    gateway.tasks.persistence.schedule_save_sensors()
+    assert mock_save_sensors.call_count == 2
+    assert mock_timer_class.call_count == 2
+    assert mock_timer_1.start.call_count == 1
+    assert mock_timer_2.start.call_count == 1
+    gateway.tasks.stop()
+    assert mock_timer_2.cancel.call_count == 1
+    assert mock_save_sensors.call_count == 3


### PR DESCRIPTION
* Separate gateway concerns by moving I/O control to new modules and classes. The two new modules are task.py with base class `Task`, and transport.py with base class `Transport`. The `Task` instance controls the threading threads or asyncio loop that should perform tasks, like poll the task queue, gateway start and stop, persistence scheduling and firmware updates. The `Transport` instance controls the communication protocol with the gateway device.
* Keep some gateway convenience methods.
* Update tests.
* Activate persistence scheduling for CLI.

**Breaking change**
- This is a small breaking change since some attributes have been moved from the gateway class, to the task class. They can still be accessed from the gateway instance, but via the `tasks` attribute on the gateway. Usually though it's not necessary to interface with the moved attributes.
- The following `gateway` attributes have been moved:
  - `gateway.loop`
  - `gateway.ota`
  - `gateway.queue`
  - `gateway.persistence`
- The above attributes can be accessed like this now:
  - `gateway.tasks.loop`
  - `gateway.tasks.ota`
  - `gateway.tasks.queue`
  - `gateway.tasks.persistence`