### PR TITLE
Add optional connection callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ prefix (in_prefix) for mqtt gateways.
 It's possible to register two optional callbacks on the gateway that are called
 when the connection is made and when the connection is lost to the gateway
 device. Both callbacks should accept a gateway parameter, which is the gateway
-instance.
+instance. The connection lost callback should also accept a second parameter
+for possible connection error exception argument. If connection was lost
+without error, eg when disconnecting, the error argument will be `None`.
 
 ```py
 def conn_made(gateway):
@@ -158,7 +160,7 @@ def conn_made(gateway):
 
 GATEWAY.on_conn_made = conn_made
 
-def conn_lost(gateway):
+def conn_lost(gateway, error):
   """React when the connection is lost to the gateway device."""
   pass
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ gateway. This will be the serial number of the usb device for serial gateways,
 the mac address of the connected gateway for tcp gateways or the publish topic
 prefix (in_prefix) for mqtt gateways.
 
+## Connection callbacks
+It's possible to register two optional callbacks on the gateway that are called
+when the connection is made and when the connection is lost to the gateway
+device. Both callbacks should accept a gateway parameter, which is the gateway
+instance.
+
+```py
+def conn_made(gateway):
+  """React when the connection is made to the gateway device."""
+  pass
+
+GATEWAY.on_conn_made = conn_made
+
+def conn_lost(gateway):
+  """React when the connection is lost to the gateway device."""
+  pass
+
+GATEWAY.on_conn_lost = conn_lost
+```
+
 ## Async gateway
 The serial, TCP and MQTT gateways now also have versions that support asyncio. Use the
 `AsyncSerialGateway` class, `AsyncTCPGateway` class or `AsyncMQTTGateway` class to make a gateway that

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -33,6 +33,8 @@ class Gateway:
         # Copy to allow safe modification.
         self.handlers = dict(handlers)
         self.can_log = False
+        self.on_conn_made = None
+        self.on_conn_lost = None
         self.protocol_version = protocol_version
         self.sensors = {}
         self.tasks = None

--- a/mysensors/transport.py
+++ b/mysensors/transport.py
@@ -134,21 +134,22 @@ class BaseMySensorsProtocol(serial.threaded.LineReader):
         """Handle lost connection."""
         _LOGGER.debug('Connection lost with %s', self.transport.serial)
         if exc:
-            _LOGGER.error(exc)
             self.transport.serial.close()
-            self._connection_lost()
-            self.conn_lost_callback()
-        self.transport = None
+        self._connection_lost(exc)
 
     def _connection_made(self):
         """Call connection made callbacks."""
         if self.gateway.on_conn_made is not None:
             self.gateway.on_conn_made(self.gateway)
 
-    def _connection_lost(self):
+    def _connection_lost(self, exc):
         """Call connection lost callbacks."""
         if self.gateway.on_conn_lost is not None:
-            self.gateway.on_conn_lost(self.gateway)
+            self.gateway.on_conn_lost(self.gateway, exc)
+        if exc:
+            _LOGGER.error(exc)
+            self.conn_lost_callback()
+        self.transport = None
 
 
 class AsyncMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):
@@ -157,8 +158,4 @@ class AsyncMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):
     def connection_lost(self, exc):
         """Handle lost connection."""
         _LOGGER.debug('Connection lost with %s', self.transport)
-        if exc:
-            _LOGGER.error(exc)
-            self._connection_lost()
-            self.conn_lost_callback()
-        self.transport = None
+        self._connection_lost(exc)

--- a/mysensors/transport.py
+++ b/mysensors/transport.py
@@ -122,6 +122,7 @@ class BaseMySensorsProtocol(serial.threaded.LineReader):
             _LOGGER.info('Connected to %s', self.transport.serial)
         else:
             _LOGGER.info('Connected to %s', self.transport)
+        self._connection_made()
 
     def handle_line(self, line):
         """Handle incoming string data one line at a time."""
@@ -135,8 +136,19 @@ class BaseMySensorsProtocol(serial.threaded.LineReader):
         if exc:
             _LOGGER.error(exc)
             self.transport.serial.close()
+            self._connection_lost()
             self.conn_lost_callback()
         self.transport = None
+
+    def _connection_made(self):
+        """Call connection made callbacks."""
+        if self.gateway.on_conn_made is not None:
+            self.gateway.on_conn_made(self.gateway)
+
+    def _connection_lost(self):
+        """Call connection lost callbacks."""
+        if self.gateway.on_conn_lost is not None:
+            self.gateway.on_conn_lost(self.gateway)
 
 
 class AsyncMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):
@@ -147,5 +159,6 @@ class AsyncMySensorsProtocol(BaseMySensorsProtocol, asyncio.Protocol):
         _LOGGER.debug('Connection lost with %s', self.transport)
         if exc:
             _LOGGER.error(exc)
+            self._connection_lost()
             self.conn_lost_callback()
         self.transport = None

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -97,7 +97,7 @@ def test_connection_lost(gateway, connection_transport, reconnect_callback):
 
 def test_connection_lost_callback(
         gateway, connection_transport, reconnect_callback):
-    """Test connection is lost."""
+    """Test connection is lost and that callbacks are called."""
     conn_lost = mock.MagicMock()
     gateway.on_conn_lost = conn_lost
     assert gateway.tasks.transport.protocol.transport is None

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,111 @@
+"""Test the gateway transport."""
+from unittest import mock
+
+import pytest
+
+from mysensors import Gateway
+from mysensors.task import SyncTasks
+from mysensors.transport import BaseMySensorsProtocol, Transport
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def connection_transport():
+    """Return a mock connection transport."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def reconnect_callback():
+    """Return a mock reconnect callback."""
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def gateway(connection_transport, reconnect_callback):
+    """Return gateway instance."""
+    _gateway = Gateway()
+    protocol = BaseMySensorsProtocol(_gateway, reconnect_callback)
+
+    def connect():
+        """Connect to device."""
+        protocol.connection_made(connection_transport)
+
+    transport = Transport(gateway, connect)
+    transport.connect = connect
+    transport.protocol = protocol
+    _gateway.tasks = SyncTasks(
+        _gateway.const, False, None, _gateway.sensors, transport)
+    return _gateway
+
+
+def test_connection_made(gateway, connection_transport):
+    """Test connection is made."""
+    assert gateway.tasks.transport.protocol.transport is None
+    gateway.tasks.transport.connect()
+    assert gateway.tasks.transport.protocol.transport is connection_transport
+
+
+def test_connection_made_callback(gateway, connection_transport):
+    """Test that callbacks are called when connection is made."""
+    conn_made = mock.MagicMock()
+    gateway.on_conn_made = conn_made
+    assert gateway.tasks.transport.protocol.transport is None
+    gateway.tasks.transport.connect()
+    assert gateway.tasks.transport.protocol.transport is connection_transport
+    assert conn_made.call_count == 1
+
+
+def test_handle_line(gateway):
+    """Test handle line."""
+    line = '1;255;0;0;17;1.4.1\n'
+    gateway.tasks.transport.protocol.handle_line(line)
+    gateway.tasks.run_job()
+    assert 1 in gateway.sensors
+
+
+def test_disconnect(gateway, connection_transport):
+    """Test disconnect."""
+    assert gateway.tasks.transport.protocol.transport is None
+    gateway.tasks.transport.connect()
+    assert gateway.tasks.transport.protocol.transport is connection_transport
+    gateway.tasks.transport.disconnect()
+    assert connection_transport.close.call_count == 1
+    assert gateway.tasks.transport.protocol is None
+
+
+def test_disconnect_no_connection(gateway, connection_transport):
+    """Test disconnect without active connection."""
+    assert gateway.tasks.transport.protocol is not None
+    assert gateway.tasks.transport.protocol.transport is None
+    gateway.tasks.transport.disconnect()
+    assert connection_transport.close.call_count == 0
+    assert gateway.tasks.transport.protocol is None
+
+
+def test_connection_lost(gateway, connection_transport, reconnect_callback):
+    """Test connection is lost."""
+    assert gateway.tasks.transport.protocol.transport is None
+    gateway.tasks.transport.connect()
+    assert gateway.tasks.transport.protocol.transport is connection_transport
+    gateway.tasks.transport.protocol.connection_lost('error')
+    assert connection_transport.serial.close.call_count == 1
+    assert reconnect_callback.call_count == 1
+    assert gateway.tasks.transport.protocol.transport is None
+
+
+def test_connection_lost_callback(
+        gateway, connection_transport, reconnect_callback):
+    """Test connection is lost."""
+    conn_lost = mock.MagicMock()
+    gateway.on_conn_lost = conn_lost
+    assert gateway.tasks.transport.protocol.transport is None
+    gateway.tasks.transport.connect()
+    assert gateway.tasks.transport.protocol.transport is connection_transport
+    gateway.tasks.transport.protocol.connection_lost('error')
+    assert connection_transport.serial.close.call_count == 1
+    assert conn_lost.call_count == 1
+    assert conn_lost.call_args == mock.call(gateway, 'error')
+    assert reconnect_callback.call_count == 1
+    assert gateway.tasks.transport.protocol.transport is None


### PR DESCRIPTION
* Add two optional gateway attributes that can be set with callback functions, that will be called when the connection is made and lost.
* The callbacks accept a parameter, the gateway instance as first parameter.
* The connection lost callback also accepts a second parameter with the error exception argument.

```py
from mysensors import Gateway

GATEWAY = Gateway()

def conn_made(gateway):
    """React when the connection is made to the gateway device."""
    pass

GATEWAY.on_conn_made = conn_made

def conn_lost(gateway, error):
    """React when the connection is lost to the gateway device."""
    pass

GATEWAY.on_conn_lost = conn_lost
```