### PR TITLE
Added some more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Python API for talking to a MySensors gateway (http://www.mysensors.org/). Curre
 - All gateway instances, serial, tcp (ethernet) or mqtt will run in separate threads.
 - As an alternative to running the gateway in its own thread, there are experimental implementations of all gateways using asyncio.
 
+# Installation
+You can easily install it via PIP:
+
+```pip3 install pymysensors```
+
 # Usage
 Currently the API is best used by implementing a callback handler
 
@@ -28,11 +33,12 @@ Message
     gateway - the gateway instance
     node_id - the sensor node identifier
     child_id - the child sensor id
-    type - the message type (int)
-    ack - True is message was an ACK, false otherwise
+    type - the message type, for example "set" or "presentation" (int)
+    ack - True is message was an ACK, false otherwise (0 or 1)
     sub_type - the message sub_type (int)
     payload - the payload of the message (string)
 ```
+_Note: The content of the sub_type differs according to the context. In presentation messages, the sub_type denotes S_TYPE data (such as S_INFO). In 'set' and 'req' messages the sub_type denotes V_TYPE data (such as V_TEXT)._
 
 Symbolic names for the Message types and sub_types are defined in the protocol version-specific const_X.py files.
 
@@ -58,16 +64,35 @@ ChildSensor - a child sensor
     values - a dictionary of values (V_HUM, V_TEMP, etc.)
 ```
 
+
 Getting the type and values of node 23, child sensor 4 would be performed as follows:
 
 ```python
 s_type = GATEWAY.sensors[23].children[4].type
 values = GATEWAY.sensors[23].children[4].values
 ```
+
+Similarly, printing all the sketch names of the found nodes could look like this:
+
+```
+for nodeIndex in GATEWAY.sensors:
+    print(str(GATEWAY.sensors[nodeIndex].sketch_name))
+```
+
+Getting a child object inside the event function could be:
+
+```
+try:
+    childObject = GATEWAY.sensors[message.node_id].children[message.child_id]
+    print(str(childObject))
+except Exception as ex:
+    print("Child not available yet. Error: " + str(ex))
+```
+
 To update a node child sensor value and send it to the node, use the set_child_value method in the Gateway class:
 
 ```python
-# To set sensor 1, child 1, sub-type V_LIGHT (= 2), with value 1.
+# To set sensor 1 (int), child 1 (int), sub-type V_LIGHT (= 2) (int), with value 1.
 GATEWAY.set_child_value(1, 1, 2, 1)
 ```
 
@@ -82,7 +107,7 @@ GATEWAY.start_persistence()
 ```
 
 ## Protocol version
-Set the keyword argument `protocol_version` to set which version of the MySensors serial API to use. The default value is `'1.4'`.
+Set the keyword argument `protocol_version` to set which version of the MySensors serial API to use. The default value is `'1.4'` so you probably want to change this to the latest version.
 
 ## Serial gateway
 The serial gateway also supports setting the baudrate, read timeout and reconnect timeout.
@@ -97,7 +122,8 @@ def event(message):
 GATEWAY = mysensors.SerialGateway(
   '/dev/ttyACM0', baud=115200, timeout=1.0, reconnect_timeout=10.0,
   event_callback=event, persistence=True,
-  persistence_file='somefolder/mysensors.pickle', protocol_version='1.4')
+  persistence_file='somefolder/mysensors.pickle', protocol_version='2.2')
+GATEWAY.start_persistence() # optional, remove this line if you don't need persistence.
 GATEWAY.start()
 ```
 


### PR DESCRIPTION
- Added basic installation instructions
- Added some more examples to quickly get started.
- Added note about sub_type having different content based on context.
- Changed protocol version in example to 2.2, and enabled persistence option in the example too. It's probably easier to disable than enable.