### PR TITLE
Remove Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
-sudo: required
+dist: xenial
 language: python
 cache: pip
 python:
-  - "3.4"
   - "3.5"
-# Run some envs on xenial, without globally enabling dist: xenial
-matrix:
-  include:
-    - python: 3.6
-      dist: xenial
-    - python: 3.7
-      dist: xenial
+  - "3.6"
+  - "3.7"
 # command to install dependencies
 install: pip install -U tox-travis
 # command to run tests

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Python API for talking to a MySensors gateway (http://www.mysensors.org/). Curre
 - All gateway instances, serial, tcp (ethernet) or mqtt will run in separate threads.
 - As an alternative to running the gateway in its own thread, there are experimental implementations of all gateways using asyncio.
 
+# Requirements
+pymysensors requires Python 3.5.3+.
+
 # Installation
 You can easily install it from PyPI:
 

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -1,5 +1,4 @@
 """Python implementation of MySensors API."""
-import asyncio
 import logging
 
 # pylint: disable=no-name-in-module, import-error
@@ -197,22 +196,18 @@ class BaseAsyncGateway(Gateway):
             self.const, persistence, persistence_file, self.sensors,
             transport, loop=loop)
 
-    @asyncio.coroutine
-    def start(self):
+    async def start(self):
         """Start the gateway and task allow tasks to be scheduled."""
-        yield from self.tasks.start()
+        await self.tasks.start()
 
-    @asyncio.coroutine
-    def stop(self):
+    async def stop(self):
         """Stop the gateway and stop allowing tasks for the scheduler."""
-        yield from self.tasks.stop()
+        await self.tasks.stop()
 
-    @asyncio.coroutine
-    def start_persistence(self):
+    async def start_persistence(self):
         """Load persistence file and schedule saving of persistence file."""
-        yield from self.tasks.start_persistence()
+        await self.tasks.start_persistence()
 
-    @asyncio.coroutine
-    def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
+    async def update_fw(self, nids, fw_type, fw_ver, fw_path=None):
         """Update firwmare of all node_ids in nids."""
-        yield from self.tasks.update_fw(nids, fw_type, fw_ver, fw_path=fw_path)
+        await self.tasks.update_fw(nids, fw_type, fw_ver, fw_path=fw_path)

--- a/mysensors/cli/gateway_mqtt.py
+++ b/mysensors/cli/gateway_mqtt.py
@@ -77,12 +77,11 @@ def run_mqtt_client(broker, port):
         mqttc.stop()
 
 
-@asyncio.coroutine
-def async_start_mqtt_client(loop, broker, port):
+async def async_start_mqtt_client(loop, broker, port):
     """Start async mqtt client."""
     mqttc = AsyncMQTTClient(loop, broker, port)
     try:
-        yield from mqttc.start()
+        await mqttc.start()
     except OSError as exc:
         _LOGGER.error(
             'Connecting to broker %s:%s failed, exiting: %s',
@@ -169,18 +168,16 @@ class AsyncMQTTClient(MQTTClient):
         self._client.socket().setsockopt(
             socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
 
-    @asyncio.coroutine
-    def start(self):
+    async def start(self):
         """Run the MQTT client."""
         _LOGGER.info('Start MQTT client')
         self._connect()
 
-    @asyncio.coroutine
-    def stop(self):
+    async def stop(self):
         """Stop the MQTT client."""
         _LOGGER.info('Stop MQTT client')
         self._client.disconnect()
-        yield from self.disconnected
+        await self.disconnected
 
 
 class AsyncioHelper:
@@ -225,12 +222,11 @@ class AsyncioHelper:
         """Unregister write callback."""
         self.loop.remove_writer(sock)
 
-    @asyncio.coroutine
-    def run_misc_loop(self):
+    async def run_misc_loop(self):
         """Provide loop for paho mqtt."""
         import paho.mqtt.client as mqtt  # pylint: disable=import-error
         while self._client.loop_misc() == mqtt.MQTT_ERR_SUCCESS:
             try:
-                yield from asyncio.sleep(1)
+                await asyncio.sleep(1)
             except asyncio.CancelledError:
                 break

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -1,5 +1,4 @@
 """Implement an MQTT gateway."""
-import asyncio
 import logging
 
 from mysensors import BaseAsyncGateway, BaseSyncGateway, Gateway, Message
@@ -117,7 +116,7 @@ class MQTTGateway(BaseSyncGateway, BaseMQTTGateway):
 class AsyncMQTTGateway(BaseAsyncGateway, BaseMQTTGateway):
     """MySensors async MQTT client gateway."""
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, useless-super-delegation
 
     def __init__(
             self, pub_callback, sub_callback, loop=None, in_prefix='',
@@ -128,8 +127,7 @@ class AsyncMQTTGateway(BaseAsyncGateway, BaseMQTTGateway):
             out_prefix=out_prefix, retain=retain)
         super().__init__(transport, loop=loop, **kwargs)
 
-    @asyncio.coroutine
-    def get_gateway_id(self):
+    async def get_gateway_id(self):
         """Return a unique id for the gateway."""
         return super().get_gateway_id()
 
@@ -218,7 +216,6 @@ class MQTTSyncTransport(MQTTTransport):
 class MQTTAsyncTransport(MQTTTransport):
     """TCP async version of transport class."""
 
-    @asyncio.coroutine
-    def connect(self):
+    async def connect(self):
         """Connect to the transport."""
         self.gateway.init_topics()

--- a/mysensors/gateway_serial.py
+++ b/mysensors/gateway_serial.py
@@ -73,23 +73,21 @@ class AsyncSerialGateway(BaseAsyncGateway, BaseSerialGateway):
         transport = AsyncTransport(self, async_connect, loop=loop, **kwargs)
         super().__init__(transport, *args, loop=loop, **kwargs)
 
-    @asyncio.coroutine
-    def get_gateway_id(self):
+    async def get_gateway_id(self):
         """Return a unique id for the gateway."""
-        serial_number = yield from self.tasks.loop.run_in_executor(
+        serial_number = await self.tasks.loop.run_in_executor(
             None, super().get_gateway_id)
         return serial_number
 
 
-@asyncio.coroutine
-def async_connect(transport):
+async def async_connect(transport):
     """Connect to the serial port."""
     try:
         while True:
             _LOGGER.info(
                 'Trying to connect to %s', transport.gateway.port)
             try:
-                yield from serial_asyncio.create_serial_connection(
+                await serial_asyncio.create_serial_connection(
                     transport.loop, lambda: transport.protocol,
                     transport.gateway.port, transport.gateway.baud)
                 return
@@ -99,7 +97,7 @@ def async_connect(transport):
                 _LOGGER.info(
                     'Waiting %s secs before trying to connect again',
                     transport.reconnect_timeout)
-                yield from asyncio.sleep(
+                await asyncio.sleep(
                     transport.reconnect_timeout, loop=transport.loop)
     except asyncio.CancelledError:
         _LOGGER.debug(

--- a/mysensors/gateway_tcp.py
+++ b/mysensors/gateway_tcp.py
@@ -134,23 +134,21 @@ class AsyncTCPGateway(BaseAsyncGateway, BaseTCPGateway):
             self.check_connection)
         self.cancel_check_conn = task.cancel
 
-    @asyncio.coroutine
-    def get_gateway_id(self):
+    async def get_gateway_id(self):
         """Return a unique id for the gateway."""
-        mac = yield from self.tasks.loop.run_in_executor(
+        mac = await self.tasks.loop.run_in_executor(
             None, super().get_gateway_id)
         return mac
 
 
-@asyncio.coroutine
-def async_connect(transport):
+async def async_connect(transport):
     """Connect to the socket."""
     try:
         while True:
             _LOGGER.info(
                 'Trying to connect to %s', transport.gateway.server_address)
             try:
-                yield from asyncio.wait_for(
+                await asyncio.wait_for(
                     transport.loop.create_connection(
                         lambda: transport.protocol,
                         *transport.gateway.server_address),
@@ -166,7 +164,7 @@ def async_connect(transport):
                 _LOGGER.info(
                     'Waiting %s secs before trying to connect again',
                     transport.reconnect_timeout)
-                yield from asyncio.sleep(
+                await asyncio.sleep(
                     transport.reconnect_timeout, loop=transport.loop)
             except OSError:
                 _LOGGER.error(
@@ -175,7 +173,7 @@ def async_connect(transport):
                 _LOGGER.info(
                     'Waiting %s secs before trying to connect again',
                     transport.reconnect_timeout)
-                yield from asyncio.sleep(
+                await asyncio.sleep(
                     transport.reconnect_timeout,
                     loop=transport.loop)
     except asyncio.CancelledError:

--- a/mysensors/transport.py
+++ b/mysensors/transport.py
@@ -94,10 +94,9 @@ class AsyncTransport(Transport):
             protocol = AsyncMySensorsProtocol
         self.protocol = protocol(self.gateway, conn_lost)
 
-    @asyncio.coroutine
-    def connect(self):
+    async def connect(self):
         """Connect to the transport."""
-        yield from self._connect(self)
+        await self._connect(self)
 
 
 class BaseMySensorsProtocol(serial.threaded.LineReader):

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Home Automation',
     ])

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py34, py35, py36, py37, lint
+envlist = py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [travis]
 python =
-  3.4: py34, lint
+  3.5: py35, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
## Background
- Python 3.4 reached end of life in March 2019.

## Changes
- Update classifiers and remove Python 3.4. Add Python 3.7.
- Update tox and travis to not run Python 3.4. Use Python 3.5 for lint env. Run all travis envs on Xenial.
- Use Python 3.5 async syntax, `async def` and `await`.
- Update readme with required Python version (3.5.3+).