### PR TITLE
Remove gen_rst script

### DIFF
--- a/scripts/gen_rst
+++ b/scripts/gen_rst
@@ -1,6 +1,0 @@
-#!/bin/sh
-if command -v pandoc >/dev/null ; then
-  pandoc --from=markdown --to=rst README.md -o README.rst
-else
-  echo "Install pandoc to generate README.rst"
-fi


### PR DESCRIPTION
* We use markdown option for pypi description, so we don't need to generate an rst readme.