### PR TITLE
Fix node internal state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,6 @@ GATEWAY.start_persistence()
 
 Set the keyword argument `protocol_version` to set which version of the MySensors serial API to use. The default value is `'1.4'`. Set the `protocol_version` to the version you're using.
 
-### Echo(ACK) default value for `Set` requests
-
-Set the keyword argument `use_ack_when_set_values` to `True` (default `False`) if you want `ack` flag to be enabled for `Set` requests. Primary required to control this flag during smart sleep nodes update.
-
 ### Serial gateway
 
 The serial gateway also supports setting the baud rate, read timeout and reconnect timeout.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ GATEWAY.start_persistence()
 
 Set the keyword argument `protocol_version` to set which version of the MySensors serial API to use. The default value is `'1.4'`. Set the `protocol_version` to the version you're using.
 
+### Echo(ACK) default value for `Set` requests
+
+Set the keyword argument `use_ack_when_set_values` to `True` (default `False`) if you want `ack` flag to be enabled for `Set` requests. Primary required to control this flag during smart sleep nodes update.
+
 ### Serial gateway
 
 The serial gateway also supports setting the baud rate, read timeout and reconnect timeout.

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -106,6 +106,9 @@ class Gateway:
         msg_type = kwargs.get("msg_type", self.const.MessageType.set)
         ack = kwargs.get("ack", default_ack)
 
+        value_type = int(value_type)
+        value = str(value)
+
         msg = Message(
             node_id=sensor.sensor_id,
             child_id=child_id,

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -23,7 +23,7 @@ class Gateway:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, event_callback=None, protocol_version="1.4", **kwargs):
+    def __init__(self, event_callback=None, protocol_version="1.4"):
         """Set up Gateway."""
         protocol_version = safe_is_version(protocol_version)
         self.const = get_const(protocol_version)
@@ -38,7 +38,6 @@ class Gateway:
         self.protocol_version = protocol_version
         self.sensors = {}
         self.tasks = None
-        self.use_ack_when_set_values = kwargs.get("use_ack_when_set_values", False)
 
     def __repr__(self):
         """Return the representation."""
@@ -101,10 +100,8 @@ class Gateway:
         self, sensor, child_id, value_type, value, **kwargs
     ):
         """Create a message to set specified sensor child value."""
-        default_ack = int(self.use_ack_when_set_values)
-
         msg_type = kwargs.get("msg_type", self.const.MessageType.set)
-        ack = kwargs.get("ack", default_ack)
+        ack = kwargs.get("ack", 0)
 
         try:
             value_type = int(value_type)

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -150,11 +150,10 @@ class Gateway:
         sensor = self.sensors[sensor_id]
 
         if sensor.new_state:
-            sensor.set_child_value(
+            sensor.set_child_desired_state(
                     child_id,
                     value_type,
-                    value,
-                children=sensor.new_state
+                value
                 )
 
             return

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -24,7 +24,7 @@ class Gateway:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, event_callback=None, protocol_version="1.4"):
+    def __init__(self, event_callback=None, protocol_version="1.4", **kwargs):
         """Set up Gateway."""
         protocol_version = safe_is_version(protocol_version)
         self.const = get_const(protocol_version)
@@ -39,6 +39,7 @@ class Gateway:
         self.protocol_version = protocol_version
         self.sensors = {}
         self.tasks = None
+        self.use_ack_when_set_values = kwargs.get("use_ack_when_set_values", False)
 
     def __repr__(self):
         """Return the representation."""
@@ -99,8 +100,10 @@ class Gateway:
 
     def create_message_to_set_sensor_value(self, sensor, child_id, value_type, value, **kwargs):
         """Create a message to set specified sensor child value."""
+        default_ack = int(self.use_ack_when_set_values)
+
         msg_type = kwargs.get("msg_type", self.const.MessageType.set)
-        ack = kwargs.get("ack", 0)
+        ack = kwargs.get("ack", default_ack)
 
         msg = Message(
             node_id=sensor.sensor_id,

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -65,9 +65,9 @@ class Gateway:
         msg.gateway = self
         message_type = self.const.MessageType(msg.type)
         handler = message_type.get_handler(self.handlers)
-        msg = handler(msg)
-        msg = self._route_message(msg)
-        return msg.encode() if msg else None
+        reply = handler(msg)
+        reply = self._route_message(reply)
+        return reply.encode() if reply else None
 
     def alert(self, msg):
         """Tell anyone who wants to know that a sensor was updated."""
@@ -196,10 +196,10 @@ class Gateway:
 
         if sensor.is_smart_sleep_node:
             sensor.set_child_desired_state(
-                    child_id,
-                    value_type,
+                child_id,
+                value_type,
                 value
-                )
+            )
 
             return
 
@@ -209,7 +209,7 @@ class Gateway:
             value_type,
             value,
             **kwargs
-            )
+        )
 
         if msg_to_send is None:
             return

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -106,7 +106,20 @@ class Gateway:
         msg_type = kwargs.get("msg_type", self.const.MessageType.set)
         ack = kwargs.get("ack", default_ack)
 
-        value_type = int(value_type)
+        try:
+            value_type = int(value_type)
+        except ValueError:
+            _LOGGER.error(
+                "Not a valid message type: node %s, child %s, type %s, "
+                "sub_type %s, payload %s",
+                sensor.sensor_id,
+                child_id,
+                msg_type,
+                value_type,
+                value,
+            )
+            return None
+
         value = str(value)
 
         msg = Message(

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -124,13 +124,16 @@ class Gateway:
             or msg.type == self.const.MessageType.presentation
         ):
             return None
+
         if (
             msg.node_id not in self.sensors
             or msg.type == self.const.MessageType.stream
-            or not self.sensors[msg.node_id].new_state
+            or not self.sensors[msg.node_id].is_smart_sleep_node
         ):
             return msg
+
         self.sensors[msg.node_id].queue.append(msg.encode())
+
         return None
 
     def set_child_value(self, sensor_id, child_id, value_type, value, **kwargs):
@@ -149,7 +152,7 @@ class Gateway:
 
         sensor = self.sensors[sensor_id]
 
-        if sensor.new_state:
+        if sensor.is_smart_sleep_node:
             sensor.set_child_desired_state(
                     child_id,
                     value_type,

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -3,7 +3,6 @@ import logging
 
 # pylint: disable=no-name-in-module, import-error
 from distutils.version import LooseVersion as parse_ver
-from functools import partial
 from pathlib import Path
 
 import voluptuous as vol
@@ -98,7 +97,9 @@ class Gateway:
             self.sensors[sensorid] = Sensor(sensorid)
         return sensorid if sensorid in self.sensors else None
 
-    def create_message_to_set_sensor_value(self, sensor, child_id, value_type, value, **kwargs):
+    def create_message_to_set_sensor_value(
+        self, sensor, child_id, value_type, value, **kwargs
+    ):
         """Create a message to set specified sensor child value."""
         default_ack = int(self.use_ack_when_set_values)
 
@@ -111,7 +112,7 @@ class Gateway:
             type=msg_type,
             ack=ack,
             sub_type=value_type,
-            payload=value
+            payload=value,
         )
 
         msg_string = msg.encode()
@@ -195,20 +196,12 @@ class Gateway:
         sensor = self.sensors[sensor_id]
 
         if sensor.is_smart_sleep_node:
-            sensor.set_child_desired_state(
-                child_id,
-                value_type,
-                value
-            )
+            sensor.set_child_desired_state(child_id, value_type, value)
 
             return
 
         msg_to_send = self.create_message_to_set_sensor_value(
-            sensor,
-            child_id,
-            value_type,
-            value,
-            **kwargs
+            sensor, child_id, value_type, value, **kwargs
         )
 
         if msg_to_send is None:

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -108,12 +108,15 @@ def handle_req(msg):
     """
     if not msg.gateway.is_sensor(msg.node_id, msg.child_id):
         return None
-    value = (
-        msg.gateway.sensors[msg.node_id].children[msg.child_id].values.get(msg.sub_type)
-    )
-    if value is not None:
-        return msg.copy(type=msg.gateway.const.MessageType.set, payload=value)
-    return None
+
+    sensor = msg.gateway.sensors[msg.node_id]
+
+    value = sensor.get_desired_value(msg.child_id, msg.sub_type)
+
+    if value is None:
+        return None
+
+    return msg.copy(type=msg.gateway.const.MessageType.set, payload=value)
 
 
 @HANDLERS.register("internal")

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -36,12 +36,15 @@ def handle_smartsleep(msg):
             if new_value is None or new_value == value:
                 continue
 
-            msg.gateway.tasks.add_job(
-                sensor.set_child_value,
-                child.id,
-                value_type,
-                new_value,
+            msg_to_send = Message(
+                node_id=sensor.sensor_id,
+                child_id=child.id,
+                type=msg.gateway.const.MessageType.set,
+                sub_type=value_type,
+                payload=new_value
             )
+
+            msg.gateway.tasks.add_job(msg_to_send.encode)
 
 
 @HANDLERS.register("presentation")

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -33,10 +33,7 @@ def handle_smartsleep(msg):
                 continue
 
             msg_to_send = msg.gateway.create_message_to_set_sensor_value(
-                sensor,
-                child.id,
-                value_type,
-                new_value
+                sensor, child.id, value_type, new_value
             )
 
             if msg_to_send is None:

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -81,15 +81,17 @@ def handle_set(msg):
     """Process a set message."""
     if not msg.gateway.is_sensor(msg.node_id, msg.child_id):
         return None
-    msg.gateway.sensors[msg.node_id].set_child_value(
-        msg.child_id, msg.sub_type, msg.payload
+    msg.gateway.sensors[msg.node_id].update_child_value(
+        msg.child_id,
+        msg.sub_type,
+        msg.payload,
     )
+
     if msg.gateway.sensors[msg.node_id].new_state:
-        msg.gateway.sensors[msg.node_id].set_child_value(
+        msg.gateway.sensors[msg.node_id].set_child_desired_state(
             msg.child_id,
             msg.sub_type,
             msg.payload,
-            children=msg.gateway.sensors[msg.node_id].new_state,
         )
     msg.gateway.alert(msg)
     # Check if reboot is true

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -31,9 +31,9 @@ def handle_smartsleep(msg):
 
         sensor.new_state[child.id] = new_child_state
 
-        for value_type, value in child.values.items():
+        for value_type, _ in child.values.items():
             new_value = new_child_state.values.get(value_type)
-            if new_value is None or new_value == value:
+            if new_value is None:
                 continue
 
             msg_to_send = Message(

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -88,13 +88,6 @@ def handle_set(msg):
         msg.payload,
     )
 
-    if sensor.is_smart_sleep_node:
-        sensor.set_child_desired_state(
-            msg.child_id,
-            msg.sub_type,
-            msg.payload,
-        )
-
     msg.gateway.alert(msg)
 
     # Check if reboot is true

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -4,8 +4,6 @@ import logging
 import time
 
 from .const import SYSTEM_CHILD_ID
-from .message import Message
-from .sensor import ChildSensor
 from .util import Registry
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,13 +32,15 @@ def handle_smartsleep(msg):
             if new_value is None:
                 continue
 
-            msg_to_send = Message(
-                node_id=sensor.sensor_id,
-                child_id=child.id,
-                type=msg.gateway.const.MessageType.set,
-                sub_type=value_type,
-                payload=new_value
+            msg_to_send = msg.gateway.create_message_to_set_sensor_value(
+                sensor,
+                child.id,
+                value_type,
+                new_value
             )
+
+            if msg_to_send is None:
+                continue
 
             msg.gateway.tasks.add_job(msg_to_send.encode)
 

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -3,7 +3,6 @@ import logging
 from collections import deque
 
 import voluptuous as vol
-from voluptuous.humanize import humanize_error
 
 from .const import get_const
 from .message import Message
@@ -194,6 +193,7 @@ class Sensor:
             )
 
         msg.validate(self.protocol_version)
+
 
 class ChildSensor:
     """Represent a child sensor."""

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -81,6 +81,11 @@ class Sensor:
         self._heartbeat = is_heartbeat(value)
 
     @property
+    def is_smart_sleep_node(self):
+        """Returns True if the node uses smart sleep mode."""
+        return bool(self.new_state)
+
+    @property
     def protocol_version(self):
         """Return protocol version."""
         return self._protocol_version
@@ -102,6 +107,14 @@ class Sensor:
             return None
         self.children[child_id] = ChildSensor(child_id, child_type, description)
         return child_id
+
+    def init_smart_sleep_mode(self):
+        """Inits desired state dict for all known children."""
+        for child in self.children.values():
+            if child.id in self.new_state:
+                continue
+
+            self.new_state[child.id] = ChildSensor(child.id, child.type, child.description)
 
     def set_child_desired_state(self, child_id, value_type, value):
         """Set a desired child sensor's value for smart sleep nodes."""

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -176,9 +176,22 @@ class Sensor:
     def validate_child_state(self, child_id, value_type, value):
         """Check if we will be able to generate a set message from these values."""
         const = get_const(self.protocol_version)
-
         msg_type = const.MessageType.set
-        value_type = int(value_type)
+
+        try:
+            value_type = int(value_type)
+        except ValueError:
+            _LOGGER.error(
+                "Not a valid message type: node %s, child %s, type %s, "
+                "sub_type %s, payload %s",
+                self.sensor_id,
+                child_id,
+                msg_type,
+                value_type,
+                value,
+            )
+            return False
+
         value = str(value)
 
         msg = Message(

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -1,7 +1,6 @@
 """Handle sensor classes."""
 import logging
 from collections import deque
-from os import chown
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -110,7 +110,7 @@ class Sensor:
 
     def get_desired_value(self, child_id, value_type):
         """Return sensor state value taking into account node type."""
-        if self.children[child_id] is None:
+        if child_id not in self.children:
             return None
 
         value = None
@@ -158,6 +158,9 @@ class Sensor:
 
     def update_child_value(self, child_id, value_type, value):
         """Update a child sensor's local state."""
+        if child_id not in self.children:
+            return
+
         child = self.children[child_id]
         child.values[value_type] = value
 

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -128,6 +128,16 @@ class Sensor:
         child = self.children[child_id]
         child.values[value_type] = value
 
+        if child_id not in self.new_state:
+            return
+
+        # New state is equal to the desired state -
+        # we can clear the desired state value to indicate that no changes are required
+        new_state_child = self.new_state[child_id]
+
+        if new_state_child.values[value_type] == value:
+            new_state_child.values[value_type] = None
+
     def validate_child_state(self, child_id, value_type, value):
         """Check if we will be able to generate a set message from these values"""
         const = get_const(self.protocol_version)

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -82,7 +82,7 @@ class Sensor:
 
     @property
     def is_smart_sleep_node(self):
-        """Returns True if the node uses smart sleep mode."""
+        """Return True if the node uses smart sleep mode."""
         return bool(self.new_state)
 
     @property
@@ -109,23 +109,25 @@ class Sensor:
         return child_id
 
     def init_smart_sleep_mode(self):
-        """Inits desired state dict for all known children."""
+        """Init desired state dict for all known children."""
         for child in self.children.values():
             if child.id in self.new_state:
                 continue
 
-            self.new_state[child.id] = ChildSensor(child.id, child.type, child.description)
+            self.new_state[child.id] = ChildSensor(
+                child.id, child.type, child.description
+            )
 
     def set_child_desired_state(self, child_id, value_type, value):
         """Set a desired child sensor's value for smart sleep nodes."""
         if child_id not in self.new_state:
             _LOGGER.warning(
-                "Warning: attempt to set a desired state value on non-smart sleep node: "
-                "node %s, child %s, type %s, value %s",
+                "Warning: attempt to set a desired state value"
+                " on non-smart sleep node: node %s, child %s, type %s, value %s",
                 self.sensor_id,
                 child_id,
                 value_type,
-                value
+                value,
             )
             return
 
@@ -144,14 +146,14 @@ class Sensor:
         if child_id not in self.new_state:
             return
 
-        # New sate received from the node - 
+        # New sate received from the node -
         # we can clear the desired state value to indicate that no changes are required
         new_state_child = self.new_state[child_id]
 
         new_state_child.values[value_type] = None
 
     def validate_child_state(self, child_id, value_type, value):
-        """Check if we will be able to generate a set message from these values"""
+        """Check if we will be able to generate a set message from these values."""
         const = get_const(self.protocol_version)
 
         msg_type = const.MessageType.set
@@ -188,7 +190,6 @@ class Sensor:
             return False
 
         return True
-
 
 
 class ChildSensor:

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -1,6 +1,7 @@
 """Handle sensor classes."""
 import logging
 from collections import deque
+from os import chown
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
@@ -107,6 +108,24 @@ class Sensor:
             return None
         self.children[child_id] = ChildSensor(child_id, child_type, description)
         return child_id
+
+    def get_desired_value(self, child_id, value_type):
+        """Return sensor state value taking into account node type."""
+        if self.children[child_id] is None:
+            return None
+
+        value = None
+
+        if self.is_smart_sleep_node:
+            child = self.new_state[child_id]
+            value = child.values.get(value_type) if child else None
+
+        if value:
+            return value
+
+        child = self.children[child_id]
+
+        return child.values.get(value_type)
 
     def init_smart_sleep_mode(self):
         """Init desired state dict for all known children."""

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -176,6 +176,8 @@ class Sensor:
         const = get_const(self.protocol_version)
 
         msg_type = const.MessageType.set
+        value_type = int(value_type)
+        value = str(value)
 
         msg = Message(
             node_id=self.sensor_id,

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -144,12 +144,11 @@ class Sensor:
         if child_id not in self.new_state:
             return
 
-        # New state is equal to the desired state -
+        # New sate received from the node - 
         # we can clear the desired state value to indicate that no changes are required
         new_state_child = self.new_state[child_id]
 
-        if new_state_child.values[value_type] == value:
-            new_state_child.values[value_type] = None
+        new_state_child.values[value_type] = None
 
     def validate_child_state(self, child_id, value_type, value):
         """Check if we will be able to generate a set message from these values"""

--- a/mysensors/sensor.py
+++ b/mysensors/sensor.py
@@ -167,7 +167,7 @@ class Sensor:
         if child_id not in self.new_state:
             return
 
-        # New sate received from the node -
+        # New state received from the node -
         # we can clear the desired state value to indicate that no changes are required
         new_state_child = self.new_state[child_id]
 

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -469,18 +469,16 @@ def test_set_child_value_bad_type(gateway, add_sensor):
     """Test Gateway method set_child_value with bad type."""
     sensor = add_sensor(1)
     sensor.add_child_sensor(0, gateway.const.Presentation.S_LIGHT)
-    gateway.set_child_value(1, 0, gateway.const.SetReq.V_LIGHT, 1, msg_type="one")
-    ret = gateway.tasks.run_job()
-    assert ret is None
+    with pytest.raises(ValueError):
+        gateway.set_child_value(1, 0, gateway.const.SetReq.V_LIGHT, 1, msg_type="one")
 
 
 def test_set_child_value_bad_ack(gateway, add_sensor):
     """Test Gateway method set_child_value with bad ack."""
     sensor = add_sensor(1)
     sensor.add_child_sensor(0, gateway.const.Presentation.S_LIGHT)
-    gateway.set_child_value(1, 0, gateway.const.SetReq.V_LIGHT, 1, ack="one")
-    ret = gateway.tasks.run_job()
-    assert ret is None
+    with pytest.raises(ValueError):
+        gateway.set_child_value(1, 0, gateway.const.SetReq.V_LIGHT, 1, ack="one")
 
 
 def test_set_child_value_value_type(gateway, add_sensor):

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -626,7 +626,7 @@ def test_smartsleep(protocol_version, wake_msg):
     assert ret == "1;0;1;0;23;57\n"
     ret = gateway.tasks.run_job()
     # then instance sends new values to the node again
-    # because there were no confirmation from the node
+    # because there was no confirmation from the node
     assert ret == "1;0;1;0;23;57\n"
     # node confirms new values
     gateway.logic("1;0;1;0;23;57\n")

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -564,6 +564,31 @@ def test_set_rgbw(protocol_version):
         ("2.2", "1;255;3;0;32;500\n"),
     ],
 )
+def test_node_mark_as_smartsleep(protocol_version, wake_msg):
+    """Test that node is correctly marked as smartsleep after the heartbeat message."""
+    gateway = get_gateway(protocol_version=protocol_version)
+    sensor = get_sensor(1, gateway)
+    sensor.add_child_sensor(0, gateway.const.Presentation.S_LIGHT_LEVEL)
+    gateway.logic("1;0;1;0;23;43\n")
+    assert not sensor.is_smart_sleep_node
+
+    # heartbeat
+    gateway.logic(wake_msg)
+
+    assert sensor.is_smart_sleep_node
+
+    # check that the new_state dict was initialized
+    assert 0 in sensor.new_state
+
+
+@pytest.mark.parametrize(
+    "protocol_version, wake_msg",
+    [
+        ("2.0", "1;255;3;0;22;123456\n"),
+        ("2.1", "1;255;3;0;22;123456\n"),
+        ("2.2", "1;255;3;0;32;500\n"),
+    ],
+)
 def test_smartsleep(protocol_version, wake_msg):
     """Test smartsleep feature."""
     gateway = get_gateway(protocol_version=protocol_version)

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -460,6 +460,9 @@ def test_non_presented_child(protocol_version, return_value):
     assert 1 not in sensor.children
     ret = gateway.tasks.run_job()
     assert ret == return_value
+    gateway.set_child_value(1, 0, gateway.const.SetReq.V_LIGHT, 1)
+    ret = gateway.tasks.run_job()
+    assert ret == return_value
 
 
 def test_set_child_value_bad_type(gateway, add_sensor):

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -631,7 +631,7 @@ def test_smartsleep(protocol_version, wake_msg):
     # node confirms new values
     gateway.logic("1;0;1;0;23;57\n")
     ret = gateway.tasks.run_job()
-    # nothing actions before heartbeat
+    # no actions before heartbeat
     assert ret is None
     # heartbeat
     gateway.logic(wake_msg)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,166 @@
+"""Test task module."""
+from mysensors.sensor import ChildSensor, Sensor
+from mysensors.const import get_const
+
+
+def test_is_smart_sleep_node():
+    """Test schedule persistence on threading gateway."""
+    const = get_const("1.4")
+    sensor_id = 1
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(0, const.Presentation.S_LIGHT_LEVEL)
+
+    assert not sensor.is_smart_sleep_node
+
+    sensor.new_state[sensor_id] = {}
+
+    assert sensor.is_smart_sleep_node
+
+
+def test_init_smart_sleep_mode():
+    """Test that the new state array is populated correctly."""
+    const = get_const("1.4")
+    sensor_id = 1
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(0, const.Presentation.S_LIGHT_LEVEL)
+    sensor.add_child_sensor(1, const.Presentation.S_LIGHT_LEVEL)
+
+    assert not sensor.new_state
+
+    sensor.init_smart_sleep_mode()
+
+    assert 0 in sensor.new_state
+    assert isinstance(sensor.new_state[0], ChildSensor)
+    assert 1 in sensor.new_state
+    assert isinstance(sensor.new_state[1], ChildSensor)
+
+
+def test_get_desired_value():
+    """Test that sensor returns correct desired value in different states."""
+    const = get_const("1.4")
+    sensor_id = 1
+    child_id = 0
+    value_type = const.SetReq.V_LIGHT_LEVEL
+    wrong_child_id = 100
+    wrong_value_type = 9999
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(child_id, const.Presentation.S_LIGHT_LEVEL)
+
+    assert sensor.get_desired_value(child_id, value_type) is None
+
+    sensor.update_child_value(child_id, value_type, "50")
+    assert sensor.get_desired_value(child_id, value_type) == "50"
+
+    sensor.init_smart_sleep_mode()
+
+    sensor.set_child_desired_state(child_id, value_type, "90")
+    assert sensor.get_desired_value(child_id, value_type) == "90"
+
+    sensor.update_child_value(child_id, value_type, "70")
+    assert sensor.get_desired_value(child_id, value_type) == "70"
+
+    assert sensor.get_desired_value(wrong_child_id, value_type) is None
+    assert sensor.get_desired_value(child_id, wrong_value_type) is None
+
+
+def test_set_child_desired_state():
+    """Test that we area able to set the desired state."""
+    const = get_const("1.4")
+    sensor_id = 1
+    child_id = 0
+    value_type = const.SetReq.V_LIGHT_LEVEL
+    wrong_child_id = 100
+    wrong_value_type = 99999
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(child_id, const.Presentation.S_LIGHT_LEVEL)
+    sensor.init_smart_sleep_mode()
+
+    # able to set
+    sensor.set_child_desired_state(child_id, value_type, "50")
+    assert child_id in sensor.new_state
+    assert value_type in sensor.new_state[child_id].values
+    assert sensor.new_state[child_id].values[value_type] == "50"
+
+    # able to update
+    sensor.set_child_desired_state(child_id, value_type, "90")
+    assert sensor.new_state[child_id].values[value_type] == "90"
+
+    # does not set unknown child
+    sensor.set_child_desired_state(wrong_child_id, value_type, "50")
+    assert wrong_child_id not in sensor.new_state
+
+    # does not set wrong value type
+    sensor.set_child_desired_state(child_id, wrong_value_type, "50")
+    assert wrong_value_type not in sensor.new_state[child_id].values
+
+    # does not set wrong value type
+    sensor.set_child_desired_state(child_id, value_type, "bad value")
+    assert sensor.new_state[child_id].values[value_type] == "90"
+
+
+def test_update_child_value():
+    """Test that we can update child state."""
+    const = get_const("1.4")
+    sensor_id = 1
+    child_id = 0
+    wrong_child_id = 100
+    value_type = const.SetReq.V_LIGHT_LEVEL
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(child_id, const.Presentation.S_LIGHT_LEVEL)
+
+    assert value_type not in sensor.children[child_id].values
+
+    # able to set
+    sensor.update_child_value(child_id, value_type, "50")
+    assert sensor.children[child_id].values[value_type] == "50"
+
+    # able to update
+    sensor.update_child_value(child_id, value_type, "90")
+    assert sensor.children[child_id].values[value_type] == "90"
+
+    # does not set unknown child
+    sensor.update_child_value(wrong_child_id, value_type, "50")
+    assert wrong_child_id not in sensor.children
+
+
+def test_update_child_value_resets_new_state():
+    """Test that update of child state resets the new state."""
+    const = get_const("1.4")
+    sensor_id = 1
+    child_id = 0
+    value_type = const.SetReq.V_LIGHT_LEVEL
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(child_id, const.Presentation.S_LIGHT_LEVEL)
+    sensor.init_smart_sleep_mode()
+    sensor.set_child_desired_state(child_id, value_type, "50")
+
+    assert sensor.new_state[child_id].values[value_type] == "50"
+
+    sensor.update_child_value(child_id, value_type, "60")
+
+    assert sensor.new_state[child_id].values[value_type] is None
+
+
+def test_validate_child_state():
+    """Test that update of child state resets the new state."""
+    const = get_const("1.4")
+    sensor_id = 1
+    child_id = 0
+    value_type = const.SetReq.V_LIGHT_LEVEL
+
+    sensor = Sensor(sensor_id)
+    sensor.add_child_sensor(child_id, const.Presentation.S_LIGHT_LEVEL)
+
+    assert not sensor.validate_child_state(child_id, value_type, "bad value")
+
+    assert not sensor.validate_child_state(300, value_type, "50")
+
+    assert not sensor.validate_child_state(child_id, 9999, "50")
+
+    assert sensor.validate_child_state(child_id, value_type, "50")


### PR DESCRIPTION
Closes #362.

- Local node state is updated via message from node only (to minimize inconsistency between the real and assumed states).
- `Set` messages to smart sleep nodes will be repeated until the response from the node will be received.
- Refactoring for readability purposes
- sensor's `set_child_value` method was removed and replaced and split into `update_child_value` and `set_child_desired_state` methods (the first one updates the internal state immediately and the second one sets the target state for smart sleep nodes)