### PR TITLE
Remove loop parameter

### DIFF
--- a/async_main.py
+++ b/async_main.py
@@ -13,21 +13,25 @@ def event(message):
     print("sensor_update " + str(message.node_id))
 
 
-LOOP = asyncio.get_event_loop()
-LOOP.set_debug(True)
+async def main():
+    """Run main function."""
+    # To create a serial gateway.
+    gateway = mysensors.AsyncSerialGateway(
+        "/dev/ttyACM0", event_callback=event, protocol_version="2.1"
+    )
+    await gateway.start()
+    # To set sensor 1, child 1, sub-type V_LIGHT (= 2), with value 1.
+    # gateway.set_child_value(1, 1, 2, 1)
+    try:
+        await asyncio.sleep(0.5)
+    except asyncio.CancelledError:
+        await gateway.stop()
+        raise
+    except Exception as exc:  # pylint: disable=broad-except
+        print(exc)
+
 
 try:
-    # To create a serial gateway.
-    GATEWAY = mysensors.AsyncSerialGateway(
-        "/dev/ttyACM0", loop=LOOP, event_callback=event, protocol_version="2.1"
-    )
-    LOOP.run_until_complete(GATEWAY.start())
-    LOOP.run_forever()
+    asyncio.run(main())
 except KeyboardInterrupt:
-    GATEWAY.stop()
-    LOOP.close()
-except Exception as exc:  # pylint: disable=broad-except
-    print(exc)
-
-# To set sensor 1, child 1, sub-type V_LIGHT (= 2), with value 1.
-# GATEWAY.set_child_value(1, 1, 2, 1)
+    pass

--- a/mysensors/__init__.py
+++ b/mysensors/__init__.py
@@ -240,7 +240,6 @@ class BaseAsyncGateway(Gateway):
         self,
         transport,
         *args,
-        loop=None,
         persistence=False,
         persistence_file="mysensors.pickle",
         **kwargs,
@@ -253,7 +252,6 @@ class BaseAsyncGateway(Gateway):
             persistence_file,
             self.sensors,
             transport,
-            loop=loop,
         )
 
     async def start(self):

--- a/mysensors/cli/gateway_serial.py
+++ b/mysensors/cli/gateway_serial.py
@@ -40,5 +40,9 @@ def serial_gateway(**kwargs):
 @common_gateway_options
 def async_serial_gateway(**kwargs):
     """Start an async serial gateway."""
-    gateway = AsyncSerialGateway(event_callback=handle_msg, **kwargs)
-    run_async_gateway(gateway)
+
+    async def gateway_factory():
+        """Create the async serial gateway."""
+        return AsyncSerialGateway(event_callback=handle_msg, **kwargs), None
+
+    run_async_gateway(gateway_factory)

--- a/mysensors/cli/gateway_tcp.py
+++ b/mysensors/cli/gateway_tcp.py
@@ -40,5 +40,9 @@ def tcp_gateway(**kwargs):
 @common_gateway_options
 def async_tcp_gateway(**kwargs):
     """Start an async tcp gateway."""
-    gateway = AsyncTCPGateway(event_callback=handle_msg, **kwargs)
-    run_async_gateway(gateway)
+
+    async def gateway_factory():
+        """Create the async TCP gateway."""
+        return AsyncTCPGateway(event_callback=handle_msg, **kwargs), None
+
+    run_async_gateway(gateway_factory)

--- a/mysensors/cli/helper.py
+++ b/mysensors/cli/helper.py
@@ -1,4 +1,5 @@
 """Offer common helper functions for the CLI."""
+import asyncio
 import logging
 import time
 
@@ -38,14 +39,25 @@ def run_gateway(gateway):
         gateway.stop()
 
 
-def run_async_gateway(gateway, stop_task=None):
+def run_async_gateway(gateway_factory):
     """Run an async gateway."""
     try:
-        gateway.tasks.loop.run_until_complete(gateway.start_persistence())
-        gateway.tasks.loop.run_until_complete(gateway.start())
-        gateway.tasks.loop.run_forever()
+        asyncio.run(handle_async_gateway(gateway_factory))
     except KeyboardInterrupt:
-        gateway.tasks.loop.run_until_complete(gateway.stop())
+        pass
+
+
+async def handle_async_gateway(gateway_factory):
+    """Handle gateway."""
+    gateway, stop_task = await gateway_factory()
+    await gateway.start_persistence()
+    await gateway.start()
+
+    try:
+        while True:
+            await asyncio.sleep(0.5)
+    except asyncio.CancelledError:
+        await gateway.stop()
         if stop_task:
-            gateway.tasks.loop.run_until_complete(stop_task)
-        gateway.tasks.loop.close()
+            await stop_task()
+        raise

--- a/mysensors/gateway_mqtt.py
+++ b/mysensors/gateway_mqtt.py
@@ -137,7 +137,6 @@ class AsyncMQTTGateway(BaseAsyncGateway, BaseMQTTGateway):
         self,
         pub_callback,
         sub_callback,
-        loop=None,
         in_prefix="",
         out_prefix="",
         retain=True,
@@ -152,7 +151,7 @@ class AsyncMQTTGateway(BaseAsyncGateway, BaseMQTTGateway):
             out_prefix=out_prefix,
             retain=retain,
         )
-        super().__init__(transport, loop=loop, **kwargs)
+        super().__init__(transport, **kwargs)
 
     async def get_gateway_id(self):
         """Return a unique id for the gateway."""

--- a/mysensors/transport.py
+++ b/mysensors/transport.py
@@ -75,14 +75,14 @@ class SyncTransport(Transport):
 class AsyncTransport(Transport):
     """Async version of transport class."""
 
-    def __init__(self, *args, loop=None, protocol=None, **kwargs):
+    def __init__(self, *args, protocol=None, **kwargs):
         """Set up transport."""
         super().__init__(*args, **kwargs)
-        self.loop = loop or asyncio.get_event_loop()
 
         def conn_lost():
             """Handle connection_lost in protocol class."""
-            self.connect_task = self.loop.create_task(self.connect())
+            loop = asyncio.get_running_loop()
+            self.connect_task = loop.create_task(self.connect())
 
         if not protocol:
             protocol = AsyncMySensorsProtocol


### PR DESCRIPTION
- Remove gateway loop parameter. Passing the asyncio event loop is a legacy pattern and the standard library is deprecating it in its functions. The recommended way of getting access to the event loop is by calling `asyncio.get_running_loop`.