### PR TITLE
Add Stream event forward

### DIFF
--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -135,7 +135,7 @@ def handle_stream(msg):
     if not msg.gateway.is_sensor(msg.node_id):
         return None
     stream = msg.gateway.const.Stream(msg.sub_type)
-    msg.gateway.alert(msg)	
+    msg.gateway.alert(msg)
     handler = stream.get_handler(msg.gateway.handlers)
     if handler is None:
         return None

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -135,6 +135,7 @@ def handle_stream(msg):
     if not msg.gateway.is_sensor(msg.node_id):
         return None
     stream = msg.gateway.const.Stream(msg.sub_type)
+    msg.gateway.alert(msg)	
     handler = stream.get_handler(msg.gateway.handlers)
     if handler is None:
         return None

--- a/mysensors/handler.py
+++ b/mysensors/handler.py
@@ -135,11 +135,12 @@ def handle_stream(msg):
     if not msg.gateway.is_sensor(msg.node_id):
         return None
     stream = msg.gateway.const.Stream(msg.sub_type)
-    msg.gateway.alert(msg)
     handler = stream.get_handler(msg.gateway.handlers)
     if handler is None:
         return None
-    return handler(msg)
+    resp = handler(msg)
+    msg.gateway.alert(msg)
+    return resp
 
 
 @HANDLERS.register("ST_FIRMWARE_CONFIG_REQUEST")

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -392,7 +392,7 @@ def test_callback_for_type_stream(gateway, add_sensor):
         messages.append(message)
 
     gateway.event_callback = callback
-    sensor = add_sensor(1)
+    add_sensor(1)
     gateway.logic("1;255;4;0;0;01000200B00626E80300\n")
     assert len(messages) == 1
     assert messages[0].gateway is gateway

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -383,6 +383,28 @@ def test_callback(gateway, add_sensor):
     assert messages[0].payload == "43"
 
 
+def test_callback_for_type_stream(gateway, add_sensor):
+    """Test gateway callback function."""
+    messages = []
+
+    def callback(message):
+        """Add message to messages list."""
+        messages.append(message)
+
+    gateway.event_callback = callback
+    sensor = add_sensor(1)
+    #sensor.add_child_sensor(0, gateway.const.Presentation.S_LIGHT_LEVEL)
+    gateway.logic("1;255;4;0;0;01000200B00626E80300\n")
+    assert len(messages) == 1
+    assert messages[0].gateway is gateway
+    assert messages[0].node_id == 1
+    assert messages[0].child_id == 255
+    assert messages[0].type == 4
+    assert messages[0].ack == 0
+    assert messages[0].sub_type == 0
+    assert messages[0].payload == "01000200B00626E80300"
+
+
 def test_callback_exception(gateway, caplog):
     """Test gateway callback with exception."""
     side_effect = ValueError("test callback error")

--- a/tests/test_mysensors.py
+++ b/tests/test_mysensors.py
@@ -393,7 +393,6 @@ def test_callback_for_type_stream(gateway, add_sensor):
 
     gateway.event_callback = callback
     sensor = add_sensor(1)
-    #sensor.add_child_sensor(0, gateway.const.Presentation.S_LIGHT_LEVEL)
     gateway.logic("1;255;4;0;0;01000200B00626E80300\n")
     assert len(messages) == 1
     assert messages[0].gateway is gateway


### PR DESCRIPTION
Added the forward for the "stream" handler.

Correct: When a message of type "stream" arrives the registered handler was not aware of it. 

In my case it's used to track on GUI side the ST_FIRMWARE_* events to display the installed firmware and track the progression during the update.
