### PR TITLE
Replace crcmod dependency with crc

### DIFF
--- a/mysensors/ota.py
+++ b/mysensors/ota.py
@@ -5,7 +5,7 @@ import logging
 import os
 import struct
 
-import crcmod.predefined
+import crc
 from intelhex import IntelHex, IntelHexError
 
 FIRMWARE_BLOCK_SIZE = 16
@@ -31,9 +31,8 @@ def fw_int_to_hex(*args):
 
 def compute_crc(data):
     """Compute CRC16 of data and return an int."""
-    crc16 = crcmod.predefined.Crc("modbus")
-    crc16.update(data)
-    return int(crc16.hexdigest(), 16)
+    crc16 = crc.Calculator(crc.Crc16.MODBUS)
+    return crc16.checksum(data)
 
 
 def load_fw(path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
   "awesomeversion",
   "click",
-  "crcmod>=1.7",
+  "crc",
   "getmac",
   "IntelHex>=2.2.1",
   "pyserial>=3.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awesomeversion==25.8.0
 click==8.1.8
-crcmod==1.7
+crc==7.1.0
 getmac==0.9.5
 IntelHex==2.3.0
 paho-mqtt==2.1.0


### PR DESCRIPTION
`crcmod` was last updated 15 years ago in 2010 and doesn't provide wheels for any recent releases.
Switch to `crc` instead. It's used by a couple of Home Assistant dependencies already including `universal-silabs-flasher`.

https://pypi.org/project/crcmod/
https://pypi.org/project/crc/